### PR TITLE
検索ボックスをブロック化 (#38)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,32 @@ The function automatically enqueues the required JavaScript and CSS assets.
 
 ### Search Box
 
+The incremental FAQ search box is available in three forms.
+
+#### Using the Block
+
+Add the **FAQ Search Box** block in the block editor. The block has the following options:
+
+-   **Label** — Input placeholder text.
+-   **Button Text** — Submit button label.
+
+#### Using the Shortcode
+
 You can use shortcode `hamelp-search` in page content.
 
 <pre>
 [hamelp-search label='Enter your question here.'][/hamelp-search]
 </pre>
 
-And you can call in your theme altenatively.
+#### Using the Template Function
+
+You can also call `hamelp_render_search_box()` directly from your theme templates:
 
 <pre>
-&lt;?php echo do_shortcode( '[hamelp-search][/hamelp-search]' ) ?&gt;
+&lt;?php echo hamelp_render_search_box( [
+    'label' => 'Enter your question here.',
+    'btn'   => 'Search',
+] ); ?&gt;
 </pre>
 
 ## Installation
@@ -90,6 +106,11 @@ Install itself is easy. Auto install from admin panel is recommended. Search wit
 You can contribute to our github repo. Any [issues](https://github.com/hametuha/hamelp/issues) or [PRs](https://github.com/hametuha/hamelp/pulls) are welcomed.
 
 ## Changelog
+
+### 2.3.0
+
+- Add **FAQ Search Box** block (`hamelp/search-box`). The existing `[hamelp-search]` shortcode continues to work and now shares the same render logic.
+- Expose `hamelp_render_search_box()` as a public template function so themes can render the search box without going through the shortcode parser.
 
 ### 2.2.0
 

--- a/app/Hametuha/Hamelp/Hooks/SearchBoxShortCode.php
+++ b/app/Hametuha/Hamelp/Hooks/SearchBoxShortCode.php
@@ -26,13 +26,6 @@ class SearchBoxShortCode extends ShortCode {
 	protected $dashicons = 'dashicons-search';
 
 	/**
-	 * Whether the search box has been rendered.
-	 *
-	 * @var bool
-	 */
-	protected static $rendered = false;
-
-	/**
 	 * Return label for this shortcode.
 	 *
 	 * @return string
@@ -44,52 +37,17 @@ class SearchBoxShortCode extends ShortCode {
 	/**
 	 * Render shortcode content
 	 *
-	 * @todo Should allow multiple post types.
 	 * @param array  $atts
 	 * @param string $content
 	 * @return string
 	 */
 	public function render_code( $atts, $content = '' ) {
-		$place_holder = esc_attr( $atts['label'] );
-		$button_label = esc_html( $atts['btn'] );
-		$post_types   = implode(
-			array_map(
-				function ( $post_type ) {
-					return sprintf( '<input type="hidden" name="post_type" value="%s" />', esc_attr( $post_type ) );
-				},
-				array_keys( PostType::get()->get_post_types() )
-			)
+		return hamelp_render_search_box(
+			[
+				'label' => $atts['label'],
+				'btn'   => $atts['btn'],
+			]
 		);
-		$query        = get_search_query();
-		$action       = esc_url( apply_filters( 'hamelp_endpoint', home_url( '' ) ) );
-		if ( ! self::$rendered ) {
-			wp_enqueue_script( 'hamelp-incsearch' );
-			wp_enqueue_style( 'hamelp-incsearch' );
-			wp_localize_script(
-				'hamelp-incsearch',
-				'HamelpIncSearch',
-				[
-					'endpoint' => rest_url( '/wp/v2/faq' ),
-					'found'    => __( 'Found Posts:', 'hamelp' ),
-					'notFound' => __( 'No posts found. Please change the query.', 'hamelp' ),
-				]
-			);
-			self::$rendered = true;
-		}
-		$html = <<<HTML
-			<form class="hamelp-search-box" action="{$action}">
-				{$post_types}
-				<div class="input-group">
-					<input type="search" class="form-control hamelp-search-input" name="s" placeholder="{$place_holder}" value="{$query}" />
-					<button class="btn btn-secondary hamelp-search-button" type="submit">{$button_label}</button>
-				</div>
-				<div class="hamelp-result-wrapper">
-					<div class="hamelp-result list-group">
-					</div>
-				</div>
-			</form>
-HTML;
-		return $html;
 	}
 
 	/**

--- a/hamelp.php
+++ b/hamelp.php
@@ -161,6 +161,72 @@ function hamelp_register_blocks() {
 add_action( 'init', 'hamelp_register_blocks' );
 
 /**
+ * Render FAQ incremental search box.
+ *
+ * Use this in theme templates or block render templates to output the FAQ
+ * incremental search form. The shortcode `[hamelp-search]` and the
+ * `hamelp/search-box` block both delegate to this function.
+ *
+ * @param array $args {
+ *     Optional. Search box arguments.
+ *
+ *     @type string $label         Input placeholder text. Default 'Enter keyword and hit search.'.
+ *     @type string $btn           Submit button label. Default 'Search'.
+ *     @type string $wrapper_attrs Pre-built wrapper attributes string (used by block render).
+ * }
+ * @return string HTML output.
+ */
+function hamelp_render_search_box( $args = [] ) {
+	static $localized = false;
+
+	$args = wp_parse_args(
+		$args,
+		[
+			'label'         => __( 'Enter keyword and hit search.', 'hamelp' ),
+			'btn'           => __( 'Search', 'hamelp' ),
+			'wrapper_attrs' => '',
+		]
+	);
+
+	wp_enqueue_script( 'hamelp-incsearch' );
+	wp_enqueue_style( 'hamelp-incsearch' );
+	if ( ! $localized ) {
+		wp_localize_script(
+			'hamelp-incsearch',
+			'HamelpIncSearch',
+			[
+				'endpoint' => rest_url( '/wp/v2/faq' ),
+				'found'    => __( 'Found Posts:', 'hamelp' ),
+				'notFound' => __( 'No posts found. Please change the query.', 'hamelp' ),
+			]
+		);
+		$localized = true;
+	}
+
+	$post_type_inputs = '';
+	foreach ( array_keys( \Hametuha\Hamelp\Hooks\PostType::get()->get_post_types() ) as $post_type ) {
+		$post_type_inputs .= sprintf( '<input type="hidden" name="post_type" value="%s" />', esc_attr( $post_type ) );
+	}
+
+	$query  = get_search_query();
+	$action = esc_url( apply_filters( 'hamelp_endpoint', home_url( '' ) ) );
+
+	if ( empty( $args['wrapper_attrs'] ) ) {
+		$args['wrapper_attrs'] = 'class="hamelp-search-box"';
+	}
+
+	return sprintf(
+		'<form %1$s action="%2$s">%3$s<div class="input-group"><input type="search" class="form-control hamelp-search-input" name="s" placeholder="%4$s" value="%5$s" /><button class="btn btn-secondary hamelp-search-button" type="submit">%6$s</button></div><div class="hamelp-result-wrapper"><div class="hamelp-result list-group"></div></div></form>',
+		$args['wrapper_attrs'],
+		$action,
+		$post_type_inputs,
+		esc_attr( $args['label'] ),
+		esc_attr( $query ),
+		esc_html( $args['btn'] )
+	);
+}
+
+/**
  * Render AI Overview widget.
  *
  * Use this in theme templates to output the AI FAQ search form.

--- a/src/blocks/search-box/block.json
+++ b/src/blocks/search-box/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "hamelp/search-box",
+	"title": "FAQ Search Box",
+	"category": "widgets",
+	"icon": "search",
+	"description": "Incremental search box for FAQ posts.",
+	"textdomain": "hamelp",
+	"attributes": {
+		"label": {
+			"type": "string",
+			"default": "Enter keyword and hit search."
+		},
+		"btn": {
+			"type": "string",
+			"default": "Search"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": [ "wide", "full" ]
+	},
+	"editorScript": "file:./index.js",
+	"style": "hamelp-incsearch",
+	"viewScript": "hamelp-incsearch",
+	"render": "file:./render.php"
+}

--- a/src/blocks/search-box/edit.js
+++ b/src/blocks/search-box/edit.js
@@ -1,0 +1,61 @@
+/**
+ * FAQ Search Box Block Editor Component
+ *
+ * @package
+ */
+
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+
+/**
+ * Edit component for FAQ Search Box block.
+ *
+ * @param {Object}   props               Block props.
+ * @param {Object}   props.attributes    Block attributes.
+ * @param {Function} props.setAttributes Function to set attributes.
+ * @return {JSX.Element} Block editor component.
+ */
+export default function Edit( { attributes, setAttributes } ) {
+	const { label, btn } = attributes;
+
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Settings', 'hamelp' ) }>
+					<TextControl
+						label={ __( 'Label', 'hamelp' ) }
+						value={ label }
+						onChange={ ( value ) =>
+							setAttributes( { label: value } )
+						}
+					/>
+					<TextControl
+						label={ __( 'Button Text', 'hamelp' ) }
+						value={ btn }
+						onChange={ ( value ) =>
+							setAttributes( { btn: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...useBlockProps( { className: 'hamelp-search-box' } ) }>
+				<div className="input-group">
+					<input
+						type="search"
+						className="form-control"
+						placeholder={ label }
+						disabled
+					/>
+					<button
+						type="button"
+						className="btn btn-secondary"
+						disabled
+					>
+						{ btn }
+					</button>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/search-box/index.js
+++ b/src/blocks/search-box/index.js
@@ -1,0 +1,14 @@
+/**
+ * FAQ Search Box Block
+ *
+ * @package
+ */
+
+import { registerBlockType } from '@wordpress/blocks';
+import Edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata.name, {
+	edit: Edit,
+	save: () => null, // Dynamic block.
+} );

--- a/src/blocks/search-box/render.php
+++ b/src/blocks/search-box/render.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * FAQ Search Box Block Render Template
+ *
+ * @package hamelp
+ * @var array    $attributes Block attributes.
+ * @var string   $content    Block content.
+ * @var WP_Block $block      Block instance.
+ */
+
+$wrapper_attributes = get_block_wrapper_attributes(
+	[
+		'class' => 'hamelp-search-box',
+	]
+);
+
+echo hamelp_render_search_box( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	[
+		'label'         => $attributes['label'] ?? __( 'Enter keyword and hit search.', 'hamelp' ),
+		'btn'           => $attributes['btn'] ?? __( 'Search', 'hamelp' ),
+		'wrapper_attrs' => $wrapper_attributes,
+	]
+);

--- a/src/scss/incsearch.scss
+++ b/src/scss/incsearch.scss
@@ -2,20 +2,54 @@
  * Incremental search styles for Hamelp
  *
  * @handle hamelp-incsearch
+ *
+ * Positional rules use normal selectors so they always apply.
+ * Visual fallbacks are wrapped in :where() so specificity is 0 — any theme
+ * styles or Bootstrap's .list-group/.list-group-item win automatically.
  */
 
 .hamelp {
-	&-search-box{
+	&-search-box {
 		position: relative;
 		margin: 2em 0;
 	}
-	&-result{
-		&-wrapper{
+
+	&-result {
+		&-wrapper {
 			position: absolute;
 			z-index: 100;
 			width: 100%;
 			left: 0;
 			top: 100%;
 		}
+	}
+}
+
+:where(.hamelp-result) {
+	background: #fff;
+
+	&:empty {
+		display: none;
+	}
+}
+
+:where(.hamelp-result-link),
+:where(.hamelp-message) {
+	display: block;
+	padding: 0.5em 1em;
+	border: 1px solid rgba(0, 0, 0, 0.125);
+	border-bottom-width: 0;
+	color: inherit;
+	text-decoration: none;
+
+	&:last-child {
+		border-bottom-width: 1px;
+	}
+}
+
+:where(.hamelp-result-link) {
+	&:hover,
+	&:focus {
+		background: rgba(0, 0, 0, 0.05);
 	}
 }


### PR DESCRIPTION
## Summary

Issue #38: インクリメンタルサーチのショートコードを Gutenberg ブロック化しました。既存の `[hamelp-search]` ショートコードは引き続き動作するよう、共通関数 `hamelp_render_search_box()` に統合しています。

## 変更点

- **新規ブロック `hamelp/search-box`** (`src/blocks/search-box/`)
  - `block.json` で `viewScript` / `style` に既存ハンドル `hamelp-incsearch` を直接指定。フロントは既存の `incsearch.js` / `incsearch.css` を完全再利用。
- **`hamelp_render_search_box()` テンプレート関数を新規追加** (`hamelp.php`)
  - 3 経路（ブロック / ショートコード / 直接呼び出し）すべてが同一 HTML を出力。
- **`SearchBoxShortCode` を共通関数経由にリファクタ**。`render_code()` は引数を渡すだけのシンプルな wrapper に。
- **incsearch 結果ドロップダウンの最低限フォールバックスタイル** (`src/scss/incsearch.scss`)
  - `:where()` で specificity 0。Bootstrap の `list-group` や テーマ CSS が当たる環境では完全に上書きされる安全設計。Bootstrap 非適用環境でも結果ドロップダウンが崩れないように `.hamelp-result-link` / `.hamelp-message` に枠線・パディングを追加。
- **README 更新**: ブロック・ショートコード・テンプレート関数の 3 つの利用方法を記載、Changelog 2.3.0 を追加。

## Test plan

- [x] PHPCS / PHPStan ともにクリア
- [x] JS lint クリア
- [x] エディタでブロックインサーターから挿入できる（Widgets カテゴリ）
- [x] Inspector Controls で `label` / `btn` を変更するとプレビューに反映
- [x] ショートコード `[hamelp-search]` が従来通り動作
- [x] ブロック・ショートコード両方で `hamelp-incsearch` ハンドルが自動 enqueue される
- [x] 検索結果ドロップダウンが Bootstrap 非適用環境でも崩れない見た目（実投稿で確認）