### PR TITLE
Make block default styles theme-aware and easy to override

### DIFF
--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -57,7 +57,7 @@
 
 :where(.hamelp-ai-overview__button) {
 	padding: 0.75rem 1.5rem;
-	border: none;
+	border: 1px solid transparent;
 	border-radius: var(--hamelp-radius, 3px);
 	background: var(--hamelp-button-bg, #1571da);
 	color: var(--hamelp-on-accent);

--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -92,6 +92,7 @@
 	display: flex;
 	align-items: center;
 	gap: 0.5rem;
+	background: #f5f5f5;
 	background: color-mix(in srgb, var(--hamelp-accent), transparent 94%);
 }
 
@@ -101,11 +102,13 @@
 }
 
 :where(.hamelp-ai-overview.has-result .hamelp-ai-overview__result) {
+	background: #f0f7fc;
 	background: color-mix(in srgb, var(--hamelp-accent), transparent 94%);
 	border: 1px solid var(--hamelp-accent);
 }
 
 :where(.hamelp-ai-overview.has-error .hamelp-ai-overview__result) {
+	background: #fef7f1;
 	background: color-mix(in srgb, var(--hamelp-error), transparent 94%);
 	border: 1px solid var(--hamelp-error);
 }
@@ -129,6 +132,7 @@
 :where(.hamelp-ai-overview__sources) {
 	margin-top: 1rem;
 	padding-top: 1rem;
+	border-top: 1px solid rgba(0, 115, 170, 0.2);
 	border-top: 1px solid color-mix(in srgb, var(--hamelp-accent), transparent 80%);
 	font-size: 0.9em;
 }
@@ -179,7 +183,7 @@
 	display: inline-block;
 	width: 1em;
 	height: 1em;
-	border: 2px solid color-mix(in srgb, var(--hamelp-accent), transparent 70%);
+	border: 2px solid #ccc;
 	border-top-color: var(--hamelp-accent);
 	border-radius: 50%;
 	animation: hamelp-spin 0.8s linear infinite;

--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -1,156 +1,200 @@
 /**
  * AI Overview Block Styles
  *
+ * Override-friendly by design:
+ *   1. All themeable values are CSS custom properties (--hamelp-*). Re-skin the
+ *      block by overriding these from your theme — no selector battles needed.
+ *   2. Every rule below is wrapped in :where() so its specificity is 0. Any
+ *      theme rule (even a single class or element selector) wins automatically.
+ *
+ * Colors derive from the active theme's color presets (--wp--preset--color--*)
+ * with sensible fallbacks, so the block adapts to any palette (navy, wine-red,
+ * etc.) out of the box.
+ *
  * @package hamelp
  */
 
-.hamelp-ai-overview {
-	&__form {
-		display: flex;
-		gap: 0.5rem;
+:where(.hamelp-ai-overview) {
+	// Theme-aware tokens (override these from your theme to re-skin the block).
+	--hamelp-accent: var(--wp--preset--color--primary, #1571da);
+	--hamelp-on-accent: var(--wp--preset--color--base, #fff);
+	--hamelp-surface: var(--wp--preset--color--base, #fff);
+	--hamelp-border: var(--wp--preset--color--contrast, rgba(0, 0, 0, 0.2));
+	--hamelp-error: var(--wp--preset--color--vivid-red, #d63638);
+	// Shared control tokens (kept in sync with the search box block so the
+	// input + button look identical across both blocks).
+	--hamelp-radius: 3px;
+	--hamelp-font-weight: 600;
+	--hamelp-button-bg: var(--hamelp-accent);
+	// Hover shade derived from the button color; the plain background
+	// declaration below wins on engines without color-mix() support.
+	--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+}
+
+:where(.hamelp-ai-overview__form) {
+	display: flex;
+	gap: 0.5rem;
+}
+
+:where(.hamelp-ai-overview__input) {
+	flex: 1;
+	padding: 0.75rem;
+	border: 1px solid var(--hamelp-border);
+	border-radius: var(--hamelp-radius, 3px);
+	background: var(--hamelp-surface);
+	color: inherit;
+	font-size: 1rem;
+}
+
+// Focus ring matches the button and the search box input (outline, 2px offset).
+:where(.hamelp-ai-overview__input:focus-visible) {
+	outline: 2px solid var(--hamelp-accent);
+	outline-offset: 2px;
+}
+
+:where(.hamelp-ai-overview__button) {
+	padding: 0.75rem 1.5rem;
+	border: none;
+	border-radius: var(--hamelp-radius, 3px);
+	background: var(--hamelp-button-bg, #1571da);
+	color: var(--hamelp-on-accent);
+	font-size: 1rem;
+	font-weight: var(--hamelp-font-weight, 600);
+	cursor: pointer;
+	transition: background 0.2s ease;
+}
+
+:where(.hamelp-ai-overview__button:hover) {
+	background: var(--hamelp-accent-hover);
+}
+
+:where(.hamelp-ai-overview__button:focus-visible) {
+	outline: 2px solid var(--hamelp-accent);
+	outline-offset: 2px;
+}
+
+:where(.hamelp-ai-overview__button:disabled) {
+	opacity: 0.5;
+	cursor: wait;
+}
+
+:where(.hamelp-ai-overview__result) {
+	margin-top: 1rem;
+	padding: 2rem;
+	border-radius: var(--hamelp-radius, 3px);
+	min-height: 2rem;
+}
+
+:where(.hamelp-ai-overview.is-loading .hamelp-ai-overview__result) {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	background: color-mix(in srgb, var(--hamelp-accent), transparent 94%);
+}
+
+:where(.hamelp-ai-overview.is-loading .hamelp-ai-overview__button) {
+	opacity: 0.5;
+	cursor: wait;
+}
+
+:where(.hamelp-ai-overview.has-result .hamelp-ai-overview__result) {
+	background: color-mix(in srgb, var(--hamelp-accent), transparent 94%);
+	border: 1px solid var(--hamelp-accent);
+}
+
+:where(.hamelp-ai-overview.has-error .hamelp-ai-overview__result) {
+	background: color-mix(in srgb, var(--hamelp-error), transparent 94%);
+	border: 1px solid var(--hamelp-error);
+}
+
+:where(.hamelp-ai-overview__answer) {
+	line-height: 1.6;
+}
+
+:where(.hamelp-ai-overview__answer p) {
+	margin: 0 0 1em;
+}
+
+:where(.hamelp-ai-overview__answer p:last-child) {
+	margin-bottom: 0;
+}
+
+:where(.hamelp-ai-overview__error) {
+	color: var(--hamelp-error);
+}
+
+:where(.hamelp-ai-overview__sources) {
+	margin-top: 1rem;
+	padding-top: 1rem;
+	border-top: 1px solid color-mix(in srgb, var(--hamelp-accent), transparent 80%);
+	font-size: 0.9em;
+}
+
+:where(.hamelp-ai-overview__sources p) {
+	margin: 0 0 0.5rem;
+	font-weight: var(--hamelp-font-weight, 600);
+}
+
+:where(.hamelp-ai-overview__sources ul) {
+	margin: 0;
+	padding-left: 1.5rem;
+}
+
+:where(.hamelp-ai-overview__sources li) {
+	margin-bottom: 0.25rem;
+}
+
+:where(.hamelp-ai-overview__sources a) {
+	color: var(--hamelp-accent);
+	text-decoration: none;
+}
+
+:where(.hamelp-ai-overview__sources a:hover) {
+	text-decoration: underline;
+}
+
+// Editor preview styles.
+:where(.hamelp-ai-overview__preview) {
+	display: flex;
+	gap: 0.5rem;
+}
+
+:where(.hamelp-ai-overview__preview input),
+:where(.hamelp-ai-overview__preview button) {
+	opacity: 0.7;
+}
+
+:where(.hamelp-ai-overview__note) {
+	margin-top: 0.5rem;
+	font-size: 0.85em;
+	color: var(--wp--preset--color--contrast-2, #666);
+	font-style: italic;
+}
+
+// Spinner.
+:where(.hamelp-ai-overview .spinner) {
+	display: inline-block;
+	width: 1em;
+	height: 1em;
+	border: 2px solid color-mix(in srgb, var(--hamelp-accent), transparent 70%);
+	border-top-color: var(--hamelp-accent);
+	border-radius: 50%;
+	animation: hamelp-spin 0.8s linear infinite;
+}
+
+@keyframes hamelp-spin {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
+// Respect users who prefer reduced motion.
+@media (prefers-reduced-motion: reduce) {
+	:where(.hamelp-ai-overview .spinner) {
+		animation-duration: 0s;
 	}
 
-	&__input {
-		flex: 1;
-		padding: 0.75rem;
-		border: 1px solid #ccc;
-		border-radius: 4px;
-		font-size: 1rem;
-
-		&:focus {
-			outline: none;
-			border-color: #0073aa;
-			box-shadow: 0 0 0 1px #0073aa;
-		}
-	}
-
-	&__button {
-		padding: 0.75rem 1.5rem;
-		background: #0073aa;
-		color: #fff;
-		border: none;
-		border-radius: 4px;
-		cursor: pointer;
-		font-size: 1rem;
-		transition: background 0.2s ease;
-
-		&:hover {
-			background: #005a87;
-		}
-
-		&:disabled {
-			opacity: 0.5;
-			cursor: wait;
-		}
-	}
-
-	&__result {
-		margin-top: 1rem;
-		padding: 1rem;
-		border-radius: 4px;
-		min-height: 2rem;
-	}
-
-	&.is-loading &__result {
-		background: #f5f5f5;
-		display: flex;
-		align-items: center;
-		gap: 0.5rem;
-	}
-
-	&.is-loading &__button {
-		opacity: 0.5;
-		cursor: wait;
-	}
-
-	&.has-result &__result {
-		background: #f0f7fc;
-		border: 1px solid #0073aa;
-	}
-
-	&.has-error &__result {
-		background: #fef7f1;
-		border: 1px solid #d63638;
-	}
-
-	&__answer {
-		line-height: 1.6;
-
-		p {
-			margin: 0 0 1em;
-
-			&:last-child {
-				margin-bottom: 0;
-			}
-		}
-	}
-
-	&__error {
-		color: #d63638;
-	}
-
-	&__sources {
-		margin-top: 1rem;
-		padding-top: 1rem;
-		border-top: 1px solid rgba(0, 115, 170, 0.2);
-		font-size: 0.9em;
-
-		p {
-			margin: 0 0 0.5rem;
-			font-weight: 600;
-		}
-
-		ul {
-			margin: 0;
-			padding-left: 1.5rem;
-		}
-
-		li {
-			margin-bottom: 0.25rem;
-		}
-
-		a {
-			color: #0073aa;
-			text-decoration: none;
-
-			&:hover {
-				text-decoration: underline;
-			}
-		}
-	}
-
-	// Editor preview styles
-	&__preview {
-		display: flex;
-		gap: 0.5rem;
-
-		input,
-		button {
-			opacity: 0.7;
-		}
-	}
-
-	&__note {
-		margin-top: 0.5rem;
-		font-size: 0.85em;
-		color: #666;
-		font-style: italic;
-	}
-
-	// Spinner
-	.spinner {
-		display: inline-block;
-		width: 1em;
-		height: 1em;
-		border: 2px solid #ccc;
-		border-top-color: #0073aa;
-		border-radius: 50%;
-		animation: hamelp-spin 0.8s linear infinite;
-	}
-
-	@keyframes hamelp-spin {
-		to {
-			transform: rotate(360deg);
-		}
+	:where(.hamelp-ai-overview__button) {
+		transition: none;
 	}
 }

--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -28,7 +28,10 @@
 	--hamelp-button-bg: var(--hamelp-accent);
 	// Hover shade derived from the button color; the plain background
 	// declaration below wins on engines without color-mix() support.
-	--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+	--hamelp-accent-hover: #005a87;
+	@supports (background: color-mix(in srgb, red, blue)) {
+		--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+	}
 }
 
 :where(.hamelp-ai-overview__form) {

--- a/src/scss/incsearch.scss
+++ b/src/scss/incsearch.scss
@@ -117,6 +117,7 @@
 :where(.hamelp-result-link) {
 	&:hover,
 	&:focus {
+		background: rgba(0, 0, 0, 0.05);
 		background: color-mix(in srgb, var(--hamelp-accent, #000), transparent 92%);
 	}
 }

--- a/src/scss/incsearch.scss
+++ b/src/scss/incsearch.scss
@@ -25,7 +25,10 @@
 		--hamelp-button-bg: var(--hamelp-accent);
 		// Hover shade derived from the button color; kept in sync with the AI
 		// Overview block so both submit buttons darken the same way on hover.
-		--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+		--hamelp-accent-hover: #005a87;
+		@supports (background: color-mix(in srgb, red, blue)) {
+			--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+		}
 
 		position: relative;
 		margin: 2em 0;

--- a/src/scss/incsearch.scss
+++ b/src/scss/incsearch.scss
@@ -6,10 +6,27 @@
  * Positional rules use normal selectors so they always apply.
  * Visual fallbacks are wrapped in :where() so specificity is 0 — any theme
  * styles or Bootstrap's .list-group/.list-group-item win automatically.
+ *
+ * Colors derive from the active theme's color presets (with fallbacks), so the
+ * search box adapts to any palette out of the box.
  */
 
 .hamelp {
 	&-search-box {
+		// Theme-aware tokens (override from your theme to re-skin).
+		--hamelp-accent: var(--wp--preset--color--primary, #1571da);
+		--hamelp-on-accent: var(--wp--preset--color--base, #fff);
+		--hamelp-surface: var(--wp--preset--color--base, #fff);
+		--hamelp-border: var(--wp--preset--color--contrast, rgba(0, 0, 0, 0.2));
+		// Shared control tokens (kept in sync with the AI Overview block so the
+		// input + button look identical across both blocks).
+		--hamelp-radius: 3px;
+		--hamelp-font-weight: 600;
+		--hamelp-button-bg: var(--hamelp-accent);
+		// Hover shade derived from the button color; kept in sync with the AI
+		// Overview block so both submit buttons darken the same way on hover.
+		--hamelp-accent-hover: color-mix(in srgb, var(--hamelp-button-bg, #1571da), #000 18%);
+
 		position: relative;
 		margin: 2em 0;
 	}
@@ -25,8 +42,55 @@
 	}
 }
 
+// Presentable defaults for the input + button so the box looks fine on block
+// themes without Bootstrap. Wrapped in :where() so theme/Bootstrap rules win.
+:where(.hamelp-search-box .input-group) {
+	display: flex;
+	gap: 0.5rem;
+}
+
+// Input/button sizing is kept identical to the AI Overview block so the two
+// blocks line up (padding 0.75rem / 0.75rem 1.5rem, font-size 1rem).
+:where(.hamelp-search-input) {
+	flex: 1 1 auto;
+	min-width: 0;
+	padding: 0.75rem;
+	border: 1px solid var(--hamelp-border);
+	border-radius: var(--hamelp-radius, 3px);
+	background: var(--hamelp-surface);
+	color: inherit;
+	font-size: 1rem;
+}
+
+:where(.hamelp-search-input:focus-visible) {
+	outline: 2px solid var(--hamelp-accent);
+	outline-offset: 2px;
+}
+
+:where(.hamelp-search-button) {
+	flex: 0 0 auto;
+	padding: 0.75rem 1.5rem;
+	border: 1px solid var(--hamelp-button-bg, #1571da);
+	border-radius: var(--hamelp-radius, 3px);
+	background: var(--hamelp-button-bg, #1571da);
+	color: var(--hamelp-on-accent);
+	font-size: 1rem;
+	font-weight: var(--hamelp-font-weight, 600);
+	cursor: pointer;
+	transition: background 0.2s ease;
+}
+
+:where(.hamelp-search-button:hover) {
+	background: var(--hamelp-accent-hover);
+}
+
+:where(.hamelp-search-button:focus-visible) {
+	outline: 2px solid var(--hamelp-accent);
+	outline-offset: 2px;
+}
+
 :where(.hamelp-result) {
-	background: #fff;
+	background: var(--hamelp-surface, #fff);
 
 	&:empty {
 		display: none;
@@ -37,7 +101,7 @@
 :where(.hamelp-message) {
 	display: block;
 	padding: 0.5em 1em;
-	border: 1px solid rgba(0, 0, 0, 0.125);
+	border: 1px solid var(--hamelp-border, rgba(0, 0, 0, 0.125));
 	border-bottom-width: 0;
 	color: inherit;
 	text-decoration: none;
@@ -50,6 +114,12 @@
 :where(.hamelp-result-link) {
 	&:hover,
 	&:focus {
-		background: rgba(0, 0, 0, 0.05);
+		background: color-mix(in srgb, var(--hamelp-accent, #000), transparent 92%);
 	}
+}
+
+// Keyboard focus stays visible by default but is overridable like everything else.
+:where(.hamelp-result-link:focus-visible) {
+	outline: 2px solid var(--hamelp-accent);
+	outline-offset: -2px;
 }


### PR DESCRIPTION
## 概要

AI Overview / インクリメンタル検索ブロックの**デフォルトスタイル**を、テーマのカラープリセットに追従し、かつテーマから上書きしやすい形に改善しました。ハードコードされていた `#0073aa` をやめ、`--wp--preset--color--*` をフォールバック付きで参照します。

## 変更点

**テーマ追従（どんなパレットでも成立）**
- 色は `--wp--preset--color--primary / base / contrast / vivid-red` を参照（フォールバック付き）。ネイビーでもワインレッドでも、テーマのパレットで自動的に着色されます。

**上書きしやすさ**
- themeable な値をすべて CSS カスタムプロパティ化：`--hamelp-accent` / `--hamelp-button-bg` / `--hamelp-on-accent` / `--hamelp-surface` / `--hamelp-border` / `--hamelp-error` / `--hamelp-radius` / `--hamelp-font-weight`。テーマは変数を指定するだけで再スキン可能。
- すべての視覚ルールを `:where()` でラップして詳細度0に。テーマ側の単一クラス/要素セレクタでも自動的に勝てます（インクリメンタル検索ブロックは既にこの方式。AI Overview も同様に統一）。

**2ブロックの統一**
- input / button の見た目と挙動を両ブロックで統一：共有 `--hamelp-radius`（3px）・`--hamelp-font-weight`（600）・`--hamelp-button-bg`（既定 `--wp--preset--color--primary`、フォールバック `#1571da`）。
- コントロール寸法を統一（padding 0.75rem / 0.75rem 1.5rem、font-size 1rem）。
- input と button はどの幅でも1行を維持。
- input / button のフォーカスリングを統一（`:focus-visible` で outline 2px / offset 2px）。
- 送信ボタンの hover も両ブロックで統一（`--hamelp-accent-hover` で同じだけ暗くする）。

**その他**
- `prefers-reduced-motion` 対応（スピナー停止）。
- 検索ボックスの input/button に、Bootstrap 非依存でも成立する見栄えのデフォルトを追加（`:where()` 内なのでテーマ/Bootstrap が優先）。

## 影響範囲・互換性

- 変更は `src/scss/incsearch.scss` と `src/blocks/ai-overview/style.scss` のみ。`/assets/` は `.gitignore` のためコミットに含めていません（リリース時に `npm run package` で再生成されます）。
- プリセット変数が未定義のテーマ（theme.json なし等）でも、フォールバック値で従来同等に表示されます。
- マークアップ・JS・PHP は変更なし。`npm run lint:css` 通過。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>