### PR TITLE
対話履歴の永続化と質問マイニング (#51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 - Change ownership to Tarosky.
 - AI Overview now supports **multi-turn conversations**. Follow-up questions keep the previous exchanges as context, and answers stack as a Q&A thread. Conversation history is held in the browser and sent with each request, so nothing is stored on the server.
 - Add `hamelp_history_window` filter to limit how many prior messages are sent to the LLM (default 10).
+- Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.
 
 ### 2.2.3
 

--- a/app/Hametuha/Hamelp/Hooks/AiOverview.php
+++ b/app/Hametuha/Hamelp/Hooks/AiOverview.php
@@ -8,6 +8,7 @@
 namespace Hametuha\Hamelp\Hooks;
 
 use Hametuha\Hamelp\Pattern\Singleton;
+use Hametuha\Hamelp\Services\ConversationStore;
 use Hametuha\Hamelp\Services\FaqSearchService;
 
 /**
@@ -43,17 +44,23 @@ class AiOverview extends Singleton {
 				'callback'            => [ $this, 'handle_request' ],
 				'permission_callback' => [ $this, 'check_permission' ],
 				'args'                => [
-					'query'   => [
+					'query'           => [
 						'required'          => true,
 						'type'              => 'string',
 						'sanitize_callback' => 'sanitize_text_field',
 					],
-					'history' => [
+					'history'         => [
 						'required' => false,
 						'type'     => 'array',
 						'default'  => [],
 						// Items are associative arrays (role/content); sanitized
 						// and windowed in FaqSearchService::prepare_history().
+					],
+					'conversation_id' => [
+						'required'          => false,
+						'type'              => 'string',
+						'default'           => '',
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -207,6 +214,25 @@ class AiOverview extends Singleton {
 
 		// Increment rate counters on successful AI call.
 		$this->increment_rate_counters();
+
+		// Persist the exchange when conversation saving is enabled (opt-in).
+		// Done only after a successful answer so empty attempts are never stored.
+		$store = new ConversationStore();
+		if ( $store->is_enabled() ) {
+			$conversation_id = (string) $request->get_param( 'conversation_id' );
+			$saved           = $store->save_turn(
+				'' !== $conversation_id ? $conversation_id : null,
+				$query,
+				(string) $result['answer'],
+				$result['cited_ids'] ?? []
+			);
+			if ( ! empty( $saved['uuid'] ) ) {
+				$result['conversation_id'] = $saved['uuid'];
+			}
+		}
+
+		// cited_ids is internal; do not expose it in the API response.
+		unset( $result['cited_ids'] );
 
 		return rest_ensure_response( $result );
 	}

--- a/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
+++ b/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Conversation history hook handler.
+ *
+ * @package hamelp
+ */
+
+namespace Hametuha\Hamelp\Hooks;
+
+use Hametuha\Hamelp\Pattern\Singleton;
+use Hametuha\Hamelp\Services\ConversationStore;
+
+/**
+ * Registers the private conversation post type used for question mining.
+ *
+ * The post type is intentionally non-public: it is not queryable on the front
+ * end and is excluded from search and the REST listing. It is only surfaced in
+ * wp-admin so site owners can review what visitors actually asked.
+ */
+class ConversationHistory extends Singleton {
+
+	/**
+	 * Initialize hooks.
+	 */
+	protected function init() {
+		add_action( 'init', [ $this, 'register_post_type' ] );
+		add_filter( 'manage_' . ConversationStore::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
+		add_action( 'manage_' . ConversationStore::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+	}
+
+	/**
+	 * Register the conversation post type.
+	 */
+	public function register_post_type() {
+		register_post_type(
+			ConversationStore::POST_TYPE,
+			[
+				'label'               => __( 'Conversations', 'hamelp' ),
+				'labels'              => [
+					'name'          => __( 'Conversations', 'hamelp' ),
+					'singular_name' => __( 'Conversation', 'hamelp' ),
+					'menu_name'     => __( 'AI Conversations', 'hamelp' ),
+				],
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'exclude_from_search' => true,
+				'show_ui'             => true,
+				'show_in_menu'        => true,
+				'show_in_rest'        => false,
+				'has_archive'         => false,
+				'rewrite'             => false,
+				'menu_icon'           => 'dashicons-format-chat',
+				'menu_position'       => 21,
+				'supports'            => [ 'title', 'editor', 'author' ],
+				'map_meta_cap'        => true,
+				// Read-only data: prevent creating new conversations by hand.
+				'capabilities'        => [
+					'create_posts' => 'do_not_allow',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Customize admin list columns.
+	 *
+	 * @param array $columns Existing columns.
+	 * @return array
+	 */
+	public function columns( $columns ) {
+		$new = [];
+		foreach ( $columns as $key => $label ) {
+			if ( 'title' === $key ) {
+				$new[ $key ]  = __( 'First Question', 'hamelp' );
+				$new['turns'] = __( 'Turns', 'hamelp' );
+			} else {
+				$new[ $key ] = $label;
+			}
+		}
+		return $new;
+	}
+
+	/**
+	 * Render custom column values.
+	 *
+	 * @param string $column  Column key.
+	 * @param int    $post_id Post ID.
+	 */
+	public function render_column( $column, $post_id ) {
+		if ( 'turns' !== $column ) {
+			return;
+		}
+		$raw   = get_post_meta( $post_id, ConversationStore::META_TURNS, true );
+		$turns = $raw ? json_decode( $raw, true ) : [];
+		echo esc_html( is_array( $turns ) ? (string) count( $turns ) : '0' );
+	}
+}

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -251,6 +251,36 @@ class Settings extends Singleton {
 				]
 			);
 		}
+
+		// Conversation history (opt-in, disabled by default for privacy).
+		register_setting(
+			self::OPTION_GROUP,
+			'hamelp_save_conversations',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => '',
+			]
+		);
+
+		add_settings_section(
+			'hamelp_history_section',
+			__( 'Conversation History', 'hamelp' ),
+			[ $this, 'render_history_section' ],
+			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'hamelp_save_conversations',
+			__( 'Save Conversations', 'hamelp' ),
+			[ $this, 'render_checkbox' ],
+			self::PAGE_SLUG,
+			'hamelp_history_section',
+			[
+				'option_name' => 'hamelp_save_conversations',
+				'description' => __( 'Store AI Overview conversations so you can review what visitors asked. Questions are saved to your database.', 'hamelp' ),
+			]
+		);
 	}
 
 	/**
@@ -338,6 +368,16 @@ class Settings extends Singleton {
 		printf(
 			'<p>%s</p>',
 			esc_html__( 'Protect the AI Overview endpoint from excessive usage. Each request costs LLM tokens.', 'hamelp' )
+		);
+	}
+
+	/**
+	 * Render conversation history section description.
+	 */
+	public function render_history_section() {
+		printf(
+			'<p>%s</p>',
+			esc_html__( 'Optionally keep a record of AI Overview conversations for question mining. Automatic deletion and privacy tools will be added in a future release.', 'hamelp' )
 		);
 	}
 

--- a/app/Hametuha/Hamelp/Services/ConversationStore.php
+++ b/app/Hametuha/Hamelp/Services/ConversationStore.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Conversation history persistence.
+ *
+ * @package hamelp
+ */
+
+namespace Hametuha\Hamelp\Services;
+
+/**
+ * Stores AI Overview conversations as a private custom post type.
+ *
+ * One conversation = one post. The first question is the post title and the
+ * first answer is the post content (for admin question-mining), while the full
+ * transcript is kept as a JSON array in post meta. Ownership is a server-issued
+ * UUID stored in meta and treated as an unguessable capability token.
+ */
+class ConversationStore {
+
+	/**
+	 * Post type slug for stored conversations.
+	 *
+	 * @var string
+	 */
+	const POST_TYPE = 'hamelp_chat';
+
+	/**
+	 * Meta key for the ownership UUID (capability token).
+	 *
+	 * @var string
+	 */
+	const META_UUID = '_hamelp_uuid';
+
+	/**
+	 * Meta key for the JSON-encoded transcript.
+	 *
+	 * @var string
+	 */
+	const META_TURNS = '_hamelp_turns';
+
+	/**
+	 * Whether conversation saving is enabled.
+	 *
+	 * Opt-in: disabled by default for privacy. Site owners enable it on the
+	 * settings page, and a filter allows per-request override.
+	 *
+	 * @return bool
+	 */
+	public function is_enabled(): bool {
+		$enabled = (bool) get_option( 'hamelp_save_conversations', '' );
+
+		/**
+		 * Filter whether to persist AI Overview conversations.
+		 *
+		 * @param bool $enabled Whether saving is enabled.
+		 */
+		return (bool) apply_filters( 'hamelp_save_conversations', $enabled );
+	}
+
+	/**
+	 * Append a completed exchange to a conversation, creating it if needed.
+	 *
+	 * Called only after a successful AI answer (so empty/abandoned attempts are
+	 * never stored). When $uuid matches an existing conversation the turns are
+	 * appended; otherwise a new conversation is created with a fresh UUID.
+	 *
+	 * @param string|null $uuid      Existing conversation UUID, or null/empty for a new one.
+	 * @param string      $question  The user's question.
+	 * @param string      $answer    The AI's answer.
+	 * @param int[]       $cited_ids Cited FAQ post IDs for this answer.
+	 * @return array{uuid:string,post_id:int}
+	 */
+	public function save_turn( ?string $uuid, string $question, string $answer, array $cited_ids ): array {
+		$question  = sanitize_textarea_field( $question );
+		$answer    = wp_kses_post( $answer );
+		$cited_ids = array_values( array_map( 'intval', $cited_ids ) );
+
+		$now            = time();
+		$turn_user      = [
+			'role'    => 'user',
+			'content' => $question,
+			'ts'      => $now,
+		];
+		$turn_assistant = [
+			'role'      => 'assistant',
+			'content'   => $answer,
+			'cited_ids' => $cited_ids,
+			'ts'        => $now,
+		];
+
+		$post = $uuid ? $this->get_post_by_uuid( $uuid ) : null;
+
+		if ( $post ) {
+			$turns   = $this->read_turns( $post->ID );
+			$turns[] = $turn_user;
+			$turns[] = $turn_assistant;
+			update_post_meta( $post->ID, self::META_TURNS, wp_slash( wp_json_encode( $turns ) ) );
+			// Touch modified time so the admin list reflects recent activity.
+			wp_update_post(
+				[
+					'ID'                => $post->ID,
+					'post_modified'     => current_time( 'mysql' ),
+					'post_modified_gmt' => current_time( 'mysql', true ),
+				]
+			);
+			return [
+				'uuid'    => (string) get_post_meta( $post->ID, self::META_UUID, true ),
+				'post_id' => $post->ID,
+			];
+		}
+
+		// New conversation.
+		$uuid    = wp_generate_uuid4();
+		$turns   = [ $turn_user, $turn_assistant ];
+		$post_id = wp_insert_post(
+			[
+				'post_type'    => self::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => $question,
+				'post_content' => $answer,
+				'post_author'  => get_current_user_id(),
+			],
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return [
+				'uuid'    => '',
+				'post_id' => 0,
+			];
+		}
+
+		update_post_meta( $post_id, self::META_UUID, $uuid );
+		update_post_meta( $post_id, self::META_TURNS, wp_slash( wp_json_encode( $turns ) ) );
+
+		return [
+			'uuid'    => $uuid,
+			'post_id' => (int) $post_id,
+		];
+	}
+
+	/**
+	 * Read a conversation by its UUID capability token.
+	 *
+	 * Returns null when no conversation matches the token. Each assistant turn
+	 * is enriched with resolved source links from its cited FAQ IDs.
+	 *
+	 * @param string $uuid Conversation UUID.
+	 * @return array|null `['id'=>int,'title'=>string,'turns'=>array[],'updated'=>int]` or null.
+	 */
+	public function get_conversation( string $uuid ): ?array {
+		if ( '' === $uuid ) {
+			return null;
+		}
+		$post = $this->get_post_by_uuid( $uuid );
+		if ( ! $post ) {
+			return null;
+		}
+
+		$search = new FaqSearchService();
+		$turns  = [];
+		foreach ( $this->read_turns( $post->ID ) as $turn ) {
+			if ( isset( $turn['role'] ) && 'assistant' === $turn['role'] ) {
+				$turn['sources'] = $search->resolve_sources( $turn['cited_ids'] ?? [] );
+			}
+			$turns[] = $turn;
+		}
+
+		return [
+			'id'      => $post->ID,
+			'title'   => get_the_title( $post ),
+			'turns'   => $turns,
+			'updated' => (int) get_post_timestamp( $post, 'modified' ),
+		];
+	}
+
+	/**
+	 * Find a conversation post by its UUID.
+	 *
+	 * @param string $uuid Conversation UUID.
+	 * @return \WP_Post|null
+	 */
+	protected function get_post_by_uuid( string $uuid ): ?\WP_Post {
+		$posts = get_posts(
+			[
+				'post_type'        => self::POST_TYPE,
+				'post_status'      => 'any',
+				'posts_per_page'   => 1,
+				'meta_key'         => self::META_UUID, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'       => $uuid, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'suppress_filters' => false,
+				'no_found_rows'    => true,
+			]
+		);
+		return $posts ? $posts[0] : null;
+	}
+
+	/**
+	 * Read and decode the stored transcript for a conversation.
+	 *
+	 * @param int $post_id Conversation post ID.
+	 * @return array[] Decoded turns (empty array when missing/invalid).
+	 */
+	protected function read_turns( int $post_id ): array {
+		$raw = get_post_meta( $post_id, self::META_TURNS, true );
+		if ( ! $raw ) {
+			return [];
+		}
+		$turns = json_decode( $raw, true );
+		return is_array( $turns ) ? $turns : [];
+	}
+}

--- a/app/Hametuha/Hamelp/Services/FaqSearchService.php
+++ b/app/Hametuha/Hamelp/Services/FaqSearchService.php
@@ -38,8 +38,9 @@ class FaqSearchService {
 		// No FAQs available.
 		if ( empty( $catalog ) ) {
 			return [
-				'answer'  => __( 'No FAQ content is available at this time.', 'hamelp' ),
-				'sources' => [],
+				'answer'    => __( 'No FAQ content is available at this time.', 'hamelp' ),
+				'sources'   => [],
+				'cited_ids' => [],
 			];
 		}
 
@@ -87,12 +88,14 @@ class FaqSearchService {
 		if ( ! $data || ! isset( $data['answer'] ) ) {
 			// JSON parse failed: treat response as plain text.
 			return [
-				'answer'  => $response,
-				'sources' => [],
+				'answer'    => $response,
+				'sources'   => [],
+				'cited_ids' => [],
 			];
 		}
 
-		// Build sources from cited IDs.
+		// Build sources from cited IDs. Restricted to the accessible catalog so
+		// inaccessible FAQs are never surfaced even if the model cites them.
 		$cited   = $data['cited_ids'] ?? [];
 		$sources = [];
 		foreach ( $catalog as $item ) {
@@ -106,9 +109,36 @@ class FaqSearchService {
 		}
 
 		return [
-			'answer'  => $data['answer'],
-			'sources' => $sources,
+			'answer'    => $data['answer'],
+			'sources'   => $sources,
+			'cited_ids' => wp_list_pluck( $sources, 'id' ),
 		];
+	}
+
+	/**
+	 * Resolve cited FAQ IDs into source link data.
+	 *
+	 * Used when rendering a stored conversation, where the in-memory catalog
+	 * is not available. Each ID is resolved to its current title and permalink.
+	 *
+	 * @param int[] $cited_ids FAQ post IDs.
+	 * @return array[] List of `['id' => int, 'title' => string, 'url' => string]`.
+	 */
+	public function resolve_sources( array $cited_ids ): array {
+		$sources = [];
+		foreach ( $cited_ids as $id ) {
+			$id   = (int) $id;
+			$post = get_post( $id );
+			if ( ! $post ) {
+				continue;
+			}
+			$sources[] = [
+				'id'    => $id,
+				'title' => get_the_title( $post ),
+				'url'   => (string) get_permalink( $post ),
+			];
+		}
+		return $sources;
 	}
 
 	/**

--- a/src/blocks/ai-overview/view.js
+++ b/src/blocks/ai-overview/view.js
@@ -48,6 +48,9 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 
 	// In-memory conversation history: [{ role: 'user'|'assistant', content }].
 	const history = [];
+	// Server-issued conversation id (only when saving is enabled). Sent back on
+	// follow-up turns so the whole conversation is appended to one record.
+	let conversationId = '';
 
 	form.addEventListener( 'submit', async ( e ) => {
 		e.preventDefault();
@@ -82,8 +85,17 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 			const data = await apiFetch( {
 				path: '/hamelp/v1/ai-overview',
 				method: 'POST',
-				data: { query, history: sentHistory },
+				data: {
+					query,
+					history: sentHistory,
+					conversation_id: conversationId,
+				},
 			} );
+
+			// Remember the conversation id so later turns append to the same record.
+			if ( data.conversation_id ) {
+				conversationId = data.conversation_id;
+			}
 
 			// Parse markdown, then replace [ID:xxx] with source links.
 			const parsedAnswer = replaceIdReferences(

--- a/tests/test-conversation-store.php
+++ b/tests/test-conversation-store.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Conversation persistence tests.
+ *
+ * @package Hamelp
+ */
+
+use Hametuha\Hamelp\Services\ConversationStore;
+
+/**
+ * Tests for ConversationStore (save/append/read by UUID).
+ */
+class ConversationStoreTest extends WP_UnitTestCase {
+
+	/**
+	 * @var ConversationStore
+	 */
+	protected $store = null;
+
+	/**
+	 * Set up store and ensure the post type is registered.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! post_type_exists( ConversationStore::POST_TYPE ) ) {
+			\Hametuha\Hamelp\Hooks\ConversationHistory::get()->register_post_type();
+		}
+		$this->store = new ConversationStore();
+	}
+
+	/**
+	 * Saving is opt-in: disabled by default, toggled by option and filter.
+	 */
+	public function test_is_enabled() {
+		$this->assertFalse( $this->store->is_enabled() );
+
+		update_option( 'hamelp_save_conversations', '1' );
+		$this->assertTrue( $this->store->is_enabled() );
+
+		update_option( 'hamelp_save_conversations', '' );
+		$filter = static function () {
+			return true;
+		};
+		add_filter( 'hamelp_save_conversations', $filter );
+		$this->assertTrue( $this->store->is_enabled() );
+		remove_filter( 'hamelp_save_conversations', $filter );
+	}
+
+	/**
+	 * A new conversation creates one post with title=Q, content=A, 2 turns.
+	 */
+	public function test_save_turn_creates_conversation() {
+		$saved = $this->store->save_turn( null, 'How do I return an item?', 'Within 30 days.', [] );
+
+		$this->assertNotEmpty( $saved['uuid'] );
+		$this->assertGreaterThan( 0, $saved['post_id'] );
+
+		$post = get_post( $saved['post_id'] );
+		$this->assertSame( ConversationStore::POST_TYPE, $post->post_type );
+		$this->assertSame( 'How do I return an item?', $post->post_title );
+		$this->assertStringContainsString( 'Within 30 days.', $post->post_content );
+
+		$turns = json_decode( get_post_meta( $saved['post_id'], ConversationStore::META_TURNS, true ), true );
+		$this->assertCount( 2, $turns );
+		$this->assertSame( 'user', $turns[0]['role'] );
+		$this->assertSame( 'assistant', $turns[1]['role'] );
+	}
+
+	/**
+	 * A matching UUID appends to the same post instead of creating a new one.
+	 */
+	public function test_save_turn_appends_to_same_post() {
+		$first = $this->store->save_turn( null, 'Q1', 'A1', [] );
+		$again = $this->store->save_turn( $first['uuid'], 'Q2', 'A2', [] );
+
+		$this->assertSame( $first['post_id'], $again['post_id'] );
+		$this->assertSame( $first['uuid'], $again['uuid'] );
+
+		$turns = json_decode( get_post_meta( $first['post_id'], ConversationStore::META_TURNS, true ), true );
+		$this->assertCount( 4, $turns );
+		$this->assertSame( 'Q2', $turns[2]['content'] );
+		$this->assertSame( 'A2', $turns[3]['content'] );
+
+		// Only one conversation post exists.
+		$count = ( new WP_Query(
+			[
+				'post_type'      => ConversationStore::POST_TYPE,
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			]
+		) )->found_posts;
+		$this->assertSame( 1, $count );
+	}
+
+	/**
+	 * An unknown/empty UUID with a follow-up starts a fresh conversation.
+	 */
+	public function test_unknown_uuid_creates_new() {
+		$saved = $this->store->save_turn( 'nonexistent-uuid', 'Q', 'A', [] );
+		$this->assertNotEmpty( $saved['uuid'] );
+		$this->assertNotSame( 'nonexistent-uuid', $saved['uuid'] );
+	}
+
+	/**
+	 * get_conversation returns the transcript for a matching UUID, null otherwise.
+	 */
+	public function test_get_conversation() {
+		$faq   = self::factory()->post->create(
+			[
+				'post_type'  => 'faq',
+				'post_title' => 'Return policy',
+			]
+		);
+		$saved = $this->store->save_turn( null, 'Can I return?', 'Yes [ID:' . $faq . ']', [ $faq ] );
+
+		$conv = $this->store->get_conversation( $saved['uuid'] );
+		$this->assertIsArray( $conv );
+		$this->assertSame( 'Can I return?', $conv['title'] );
+		$this->assertCount( 2, $conv['turns'] );
+		// Assistant turn is enriched with resolved sources.
+		$this->assertSame( $faq, $conv['turns'][1]['sources'][0]['id'] );
+		$this->assertSame( 'Return policy', $conv['turns'][1]['sources'][0]['title'] );
+
+		$this->assertNull( $this->store->get_conversation( 'no-such-uuid' ) );
+		$this->assertNull( $this->store->get_conversation( '' ) );
+	}
+
+	/**
+	 * Stored content is sanitized (script tags removed from the question).
+	 */
+	public function test_question_sanitized() {
+		$saved = $this->store->save_turn( null, '<script>alert(1)</script>Hello', 'Answer', [] );
+		$post  = get_post( $saved['post_id'] );
+		$this->assertStringNotContainsString( '<script>', $post->post_title );
+		$this->assertStringContainsString( 'Hello', $post->post_title );
+	}
+}


### PR DESCRIPTION
## 概要

#44 のステートレス多ターン対話の上に**永続化レイヤー**を載せ、サイトオーナーが「実際に何を聞かれたか」を管理画面で一覧できるようにしました（質問マイニング）。Part of #51

**保存はプライバシー配慮でデフォルトOFFのオプトイン**。保存OFF時は #44 と完全に同一のステートレス動作を保ちます。

## 変更点

- **`Services/ConversationStore.php`（新規）**: 保存/追記/UUID読み取り/サニタイズを集約。1会話=1投稿、`post_title`=最初の質問・`post_content`=最初の回答、全ターンは `_hamelp_turns`(JSON) meta、`_hamelp_uuid` meta が所有トークン。
- **`Hooks/ConversationHistory.php`（新規）**: 非公開 post type `hamelp_chat` を登録（`public=false`/REST一覧・検索から除外/管理UIのみ）。一覧に「最初の質問」「ターン数」カラム。`Add New` は無効化。
- **`Hooks/AiOverview.php`**: `conversation_id` 引数を追加。応答成立後、保存ONなら `ConversationStore::save_turn()` し `conversation_id` をレスポンスで返す（生成自体が既存レート制限下＝匿名スパム対策）。
- **`Hooks/Settings.php`**: 「Conversation History」セクションに **Save Conversations** トグル（既定OFF）。説明に保持/削除は今後（#52）と明記。
- **`Services/FaqSearchService.php`**: sources 構築を `resolve_sources()` に切り出し、`generate_overview` の戻り値に `cited_ids` を追加（API応答からは除外）。
- **`src/blocks/ai-overview/view.js`**: `conversation_id` をセッション内メモリで往復（同一会話が1投稿に追記される）。
- テスト・README changelog 追記。

## セキュリティ

- UUID は**サーバー生成**（`wp_generate_uuid4()`）。クライアントが id を任意設定できないので他人の会話への注入を防ぐ。
- 質問は `sanitize_textarea_field`、回答は `wp_kses_post`。表示側 `parseMarkdown` のエスケープと二重防御。
- 保存した会話を他ユーザーのコンテキストや FAQ カタログに自動流用しない。

## 後方互換

保存OFF（既定）では `conversation_id` を発行せず、#44 と完全に同一のステートレス動作。

## 検証

- `composer lint` 14/14、`composer phpstan` No errors、`npm run lint:js`/`lint:css`、`npm run package`、`npm test` 15/15（新規6）。
- **Playwright E2E（wp-env）**: 保存ONで2ターン会話 → `hamelp_chat` が**1投稿だけ**生成され（2ターン目で別投稿が増えない）、title=最初の質問・content=最初の回答・`_hamelp_turns` 4件・UUID を確認。保存OFF（既定）では投稿が増えず会話は正常動作（後方互換）。

## やらないこと（後続）

- 見返しUI（読み取りREST `GET conversation/<uuid>`、`hamelp/conversation-history` ブロック/ショートコード、localStorage 一覧）→ **#56**
- 保持期限/自動削除/GDPRエクスポート・消去 → **#52**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
