### PR TITLE
対話履歴の管理UI: メタボックスとExchangesカラム (#51)

### DIFF
--- a/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
+++ b/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
@@ -26,6 +26,7 @@ class ConversationHistory extends Singleton {
 		add_action( 'init', [ $this, 'register_post_type' ] );
 		add_filter( 'manage_' . ConversationStore::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
 		add_action( 'manage_' . ConversationStore::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
+		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
 	}
 
 	/**
@@ -71,8 +72,8 @@ class ConversationHistory extends Singleton {
 		$new = [];
 		foreach ( $columns as $key => $label ) {
 			if ( 'title' === $key ) {
-				$new[ $key ]  = __( 'First Question', 'hamelp' );
-				$new['turns'] = __( 'Turns', 'hamelp' );
+				$new[ $key ]      = __( 'First Question', 'hamelp' );
+				$new['exchanges'] = __( 'Exchanges', 'hamelp' );
 			} else {
 				$new[ $key ] = $label;
 			}
@@ -87,11 +88,120 @@ class ConversationHistory extends Singleton {
 	 * @param int    $post_id Post ID.
 	 */
 	public function render_column( $column, $post_id ) {
-		if ( 'turns' !== $column ) {
+		if ( 'exchanges' !== $column ) {
 			return;
 		}
+		echo esc_html( (string) $this->count_exchanges( $this->get_turns( $post_id ) ) );
+	}
+
+	/**
+	 * Register the conversation transcript meta box.
+	 */
+	public function add_meta_boxes() {
+		add_meta_box(
+			'hamelp_conversation',
+			__( 'Conversation', 'hamelp' ),
+			[ $this, 'render_meta_box' ],
+			ConversationStore::POST_TYPE,
+			'normal',
+			'high'
+		);
+	}
+
+	/**
+	 * Render the conversation transcript meta box (read-only).
+	 *
+	 * @param \WP_Post $post Conversation post.
+	 */
+	public function render_meta_box( $post ) {
+		$uuid  = (string) get_post_meta( $post->ID, ConversationStore::META_UUID, true );
+		$turns = $this->get_turns( $post->ID );
+
+		echo '<p><strong>' . esc_html__( 'Owner token (UUID):', 'hamelp' ) . '</strong> ';
+		echo '<code>' . esc_html( $uuid ? $uuid : __( '(none)', 'hamelp' ) ) . '</code></p>';
+		echo '<p><strong>' . esc_html__( 'Exchanges:', 'hamelp' ) . '</strong> ';
+		echo esc_html( (string) $this->count_exchanges( $turns ) ) . '</p>';
+
+		if ( empty( $turns ) ) {
+			echo '<p>' . esc_html__( 'No conversation data.', 'hamelp' ) . '</p>';
+			return;
+		}
+
+		$date_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+
+		echo '<div class="hamelp-conversation-log">';
+		foreach ( $turns as $turn ) {
+			$role    = isset( $turn['role'] ) ? (string) $turn['role'] : '';
+			$is_user = 'user' === $role;
+			$label   = $is_user ? __( 'Question', 'hamelp' ) : __( 'Answer', 'hamelp' );
+			$bg      = $is_user ? '#f0f6fc' : '#f6f7f7';
+			$time    = ! empty( $turn['ts'] ) ? wp_date( $date_format, (int) $turn['ts'] ) : '';
+			$content = isset( $turn['content'] ) ? (string) $turn['content'] : '';
+
+			printf(
+				'<div style="margin:0 0 12px;padding:10px 14px;border:1px solid #dcdcde;border-radius:4px;background:%s">',
+				esc_attr( $bg )
+			);
+			printf(
+				'<p style="margin:0 0 6px;font-weight:600">%s <span style="font-weight:400;color:#787c82">%s</span></p>',
+				esc_html( $label ),
+				esc_html( $time )
+			);
+			echo '<div style="white-space:pre-wrap">' . esc_html( $content ) . '</div>';
+
+			// Cited sources for assistant turns.
+			if ( ! $is_user && ! empty( $turn['cited_ids'] ) && is_array( $turn['cited_ids'] ) ) {
+				$links = [];
+				foreach ( $turn['cited_ids'] as $cid ) {
+					$cid   = (int) $cid;
+					$title = get_the_title( $cid );
+					if ( $title ) {
+						$links[] = sprintf(
+							'<a href="%s">%s</a>',
+							esc_url( (string) get_edit_post_link( $cid ) ),
+							esc_html( $title )
+						);
+					}
+				}
+				if ( $links ) {
+					echo '<p style="margin:8px 0 0;font-size:12px;color:#787c82">'
+						. esc_html__( 'Sources:', 'hamelp' ) . ' '
+						. wp_kses( implode( ', ', $links ), [ 'a' => [ 'href' => [] ] ] )
+						. '</p>';
+				}
+			}
+			echo '</div>';
+		}
+		echo '</div>';
+	}
+
+	/**
+	 * Decode the stored transcript for a conversation post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array[] Decoded turns.
+	 */
+	protected function get_turns( $post_id ) {
 		$raw   = get_post_meta( $post_id, ConversationStore::META_TURNS, true );
 		$turns = $raw ? json_decode( $raw, true ) : [];
-		echo esc_html( is_array( $turns ) ? (string) count( $turns ) : '0' );
+		return is_array( $turns ) ? $turns : [];
+	}
+
+	/**
+	 * Count exchanges (answers) in a transcript.
+	 *
+	 * One exchange = one question + one answer, so the assistant turns are counted.
+	 *
+	 * @param array[] $turns Decoded turns.
+	 * @return int
+	 */
+	protected function count_exchanges( $turns ) {
+		$count = 0;
+		foreach ( $turns as $turn ) {
+			if ( isset( $turn['role'] ) && 'assistant' === $turn['role'] ) {
+				++$count;
+			}
+		}
+		return $count;
 	}
 }


### PR DESCRIPTION
## 概要

#51 でマージした永続化の管理画面が「投稿を開いても何も分からない」状態だったので、質問マイニングが実際に使えるよう編集画面と一覧を整えました。Part of #51

## 変更点

- **会話メタボックス**（編集画面）: 所有トークン（UUID）、やりとり件数、各ターンの質問/回答・日時、回答ごとの引用元FAQへの編集リンクを read-only 表示。
- **一覧カラム**: 「やりとり件数（Exchanges＝回答数）」を表示。

`hamelp_chat` は `show_in_rest=false` でクラシックエディタのため、メタボックスが素直に表示される。

## 検証

- `composer lint` 14/14、`composer phpstan` No errors。
- **Playwright（wp-admin）**: 実会話（3やりとり）の編集画面でメタボックスに UUID・Exchanges:3・全6ターン・引用元リンクが表示されること、一覧に Exchanges=3 カラムが出ることを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)