### PR TITLE
対話履歴の自動削除（保持ポリシー） (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 - AI Overview now supports **multi-turn conversations**. Follow-up questions keep the previous exchanges as context, and answers stack as a Q&A thread. Conversation history is held in the browser and sent with each request, so nothing is stored on the server.
 - Add `hamelp_history_window` filter to limit how many prior messages are sent to the LLM (default 10).
 - Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.
+- Add an **Auto-delete After (days)** retention setting. A daily cron removes anonymous conversations older than the configured number of days (0 = never delete). Conversations from logged-in users are never auto-deleted.
 
 ### 2.2.3
 

--- a/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
+++ b/app/Hametuha/Hamelp/Hooks/ConversationHistory.php
@@ -20,6 +20,13 @@ use Hametuha\Hamelp\Services\ConversationStore;
 class ConversationHistory extends Singleton {
 
 	/**
+	 * Cron hook for purging expired conversations.
+	 *
+	 * @var string
+	 */
+	const PURGE_HOOK = 'hamelp_purge_conversations';
+
+	/**
 	 * Initialize hooks.
 	 */
 	protected function init() {
@@ -27,6 +34,27 @@ class ConversationHistory extends Singleton {
 		add_filter( 'manage_' . ConversationStore::POST_TYPE . '_posts_columns', [ $this, 'columns' ] );
 		add_action( 'manage_' . ConversationStore::POST_TYPE . '_posts_custom_column', [ $this, 'render_column' ], 10, 2 );
 		add_action( 'add_meta_boxes', [ $this, 'add_meta_boxes' ] );
+		add_action( self::PURGE_HOOK, [ $this, 'purge_expired' ] );
+		add_action( 'init', [ $this, 'schedule_purge' ] );
+	}
+
+	/**
+	 * Ensure the daily purge event is scheduled.
+	 */
+	public function schedule_purge() {
+		if ( ! wp_next_scheduled( self::PURGE_HOOK ) ) {
+			wp_schedule_event( time() + DAY_IN_SECONDS, 'daily', self::PURGE_HOOK );
+		}
+	}
+
+	/**
+	 * Purge expired anonymous conversations based on the retention setting.
+	 *
+	 * Runs daily via wp-cron. Does nothing when the retention period is 0.
+	 */
+	public function purge_expired() {
+		$days = (int) get_option( 'hamelp_retention_days', 0 );
+		( new ConversationStore() )->purge_expired( $days );
 	}
 
 	/**

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -281,6 +281,30 @@ class Settings extends Singleton {
 				'description' => __( 'Store AI Overview conversations so you can review what visitors asked. Questions are saved to your database.', 'hamelp' ),
 			]
 		);
+
+		register_setting(
+			self::OPTION_GROUP,
+			'hamelp_retention_days',
+			[
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'default'           => 0,
+			]
+		);
+
+		add_settings_field(
+			'hamelp_retention_days',
+			__( 'Auto-delete After (days)', 'hamelp' ),
+			[ $this, 'render_number' ],
+			self::PAGE_SLUG,
+			'hamelp_history_section',
+			[
+				'option_name' => 'hamelp_retention_days',
+				'description' => __( 'Automatically delete anonymous conversations older than this many days. 0 means never delete. Conversations from logged-in users are never auto-deleted (delete the user account to remove their data).', 'hamelp' ),
+				'default'     => 0,
+				'min'         => 0,
+			]
+		);
 	}
 
 	/**

--- a/app/Hametuha/Hamelp/Services/ConversationStore.php
+++ b/app/Hametuha/Hamelp/Services/ConversationStore.php
@@ -175,6 +175,50 @@ class ConversationStore {
 	}
 
 	/**
+	 * Delete anonymous conversations older than the retention period.
+	 *
+	 * Only anonymous conversations (post_author = 0) are purged. Conversations
+	 * owned by a logged-in user are kept, because their data is removed when the
+	 * user account itself is deleted. A value of 0 (or less) disables purging.
+	 *
+	 * @param int $days Retention period in days. 0 disables deletion.
+	 * @param int $limit Maximum conversations to delete per run (batch cap).
+	 * @return int Number of conversations deleted.
+	 */
+	public function purge_expired( int $days, int $limit = 200 ): int {
+		if ( $days <= 0 ) {
+			return 0;
+		}
+
+		$before = gmdate( 'Y-m-d H:i:s', time() - $days * DAY_IN_SECONDS );
+
+		$ids = get_posts(
+			[
+				'post_type'      => self::POST_TYPE,
+				'post_status'    => 'any',
+				'author__in'     => [ 0 ], // Anonymous only; logged-in conversations are excluded.
+				'posts_per_page' => $limit,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+				'date_query'     => [
+					[
+						'column' => 'post_modified_gmt',
+						'before' => $before,
+					],
+				],
+			]
+		);
+
+		$count = 0;
+		foreach ( $ids as $id ) {
+			if ( wp_delete_post( (int) $id, true ) ) {
+				++$count;
+			}
+		}
+		return $count;
+	}
+
+	/**
 	 * Find a conversation post by its UUID.
 	 *
 	 * @param string $uuid Conversation UUID.

--- a/hamelp.php
+++ b/hamelp.php
@@ -66,6 +66,16 @@ function hamelp_activate() {
 }
 register_activation_hook( __FILE__, 'hamelp_activate' );
 
+/**
+ * Plugin deactivation handler.
+ *
+ * Clears scheduled cron events so they do not linger after deactivation.
+ */
+function hamelp_deactivate() {
+	wp_clear_scheduled_hook( 'hamelp_purge_conversations' );
+}
+register_deactivation_hook( __FILE__, 'hamelp_deactivate' );
+
 
 /**
  * Register all file in wp-dependencies.json

--- a/tests/test-conversation-store.php
+++ b/tests/test-conversation-store.php
@@ -134,4 +134,66 @@ class ConversationStoreTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<script>', $post->post_title );
 		$this->assertStringContainsString( 'Hello', $post->post_title );
 	}
+
+	/**
+	 * Backdate a conversation's modified time so it looks expired.
+	 *
+	 * @param int $post_id Conversation post ID.
+	 * @param int $days    How many days in the past to set.
+	 */
+	protected function backdate( int $post_id, int $days ) {
+		global $wpdb;
+		$old = gmdate( 'Y-m-d H:i:s', time() - $days * DAY_IN_SECONDS );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->update(
+			$wpdb->posts,
+			[
+				'post_modified'     => $old,
+				'post_modified_gmt' => $old,
+			],
+			[ 'ID' => $post_id ]
+		);
+		clean_post_cache( $post_id );
+	}
+
+	/**
+	 * A retention period of 0 disables deletion.
+	 */
+	public function test_purge_disabled_when_zero() {
+		$saved = $this->store->save_turn( null, 'Q', 'A', [] );
+		$this->backdate( $saved['post_id'], 100 );
+
+		$this->assertSame( 0, $this->store->purge_expired( 0 ) );
+		$this->assertNotNull( get_post( $saved['post_id'] ) );
+	}
+
+	/**
+	 * Expired anonymous conversations are deleted; recent ones are kept.
+	 */
+	public function test_purge_deletes_expired_anonymous() {
+		$old    = $this->store->save_turn( null, 'Old', 'A', [] );
+		$recent = $this->store->save_turn( null, 'Recent', 'A', [] );
+		$this->backdate( $old['post_id'], 40 );
+
+		$deleted = $this->store->purge_expired( 30 );
+
+		$this->assertSame( 1, $deleted );
+		$this->assertNull( get_post( $old['post_id'] ) );
+		$this->assertNotNull( get_post( $recent['post_id'] ) );
+	}
+
+	/**
+	 * Conversations owned by a logged-in user are never auto-deleted.
+	 */
+	public function test_purge_keeps_logged_in_user_conversations() {
+		$user = self::factory()->user->create();
+		wp_set_current_user( $user );
+		$mine = $this->store->save_turn( null, 'Mine', 'A', [] );
+		wp_set_current_user( 0 );
+
+		$this->backdate( $mine['post_id'], 40 );
+
+		$this->assertSame( 0, $this->store->purge_expired( 30 ) );
+		$this->assertNotNull( get_post( $mine['post_id'] ) );
+	}
 }


### PR DESCRIPTION
## 概要

#51 で保存した対話履歴に**保持ポリシー（自動削除）**を追加。Close #52

- **保持日数設定** `Auto-delete After (days)`（既定 **0 = 削除しない**）を設定画面の Conversation History セクションに追加。
- **日次 cron** `hamelp_purge_conversations` が、期限を超えた**匿名会話のみ**を削除。
- **ログインユーザーの会話は自動削除しない**（ユーザーアカウントを削除すればそのデータも消えるため）。

## 変更点

- `ConversationStore::purge_expired( int $days )`: `post_author = 0`（匿名）かつ `post_modified_gmt` が N 日より前の会話を削除。`$days <= 0` で無効。
- `Hooks/ConversationHistory.php`: 日次 cron をスケジュール＋フック。設定値を読んで purge を実行。
- `Hooks/Settings.php`: `hamelp_retention_days` 数値フィールド（既定0、min0）。
- `hamelp.php`: 無効化時に cron をクリア（`register_deactivation_hook`）。

## 検証

- `composer lint` / `composer phpstan` No errors、`npm test` 18/18（新規3：0無効/匿名期限切れ削除/ログインユーザー保持）。
- **wp-cli E2E**: cron が `1 day` で登録されていること、保持7日設定で10日前の匿名会話が purge フック発火で削除されることを確認。

## やらないこと（必要なら別途）

WP 標準のプライバシー連携（`wp_privacy_personal_data_exporters` / eraser フックによるエクスポート/消去リクエスト対応）は今回未実装。匿名会話はメール紐付けが無く対象外、ログインユーザー分はユーザー削除で対応できるため。必要なら別イシューで追加可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)