### PR TITLE
AI Overview にモード設定（Conversation/Single/Disabled）を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 - Add `hamelp_history_window` filter to limit how many prior messages are sent to the LLM (default 10).
 - Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.
 - Add an **Auto-delete After (days)** retention setting. A daily cron removes anonymous conversations older than the configured number of days (0 = never delete). Conversations from logged-in users are never auto-deleted.
+- Add an AI Overview **Mode** setting: *Conversation* (multi-turn, default), *Single answer* (no follow-up, lower cost), or *Disabled*. Use Single/Disabled to cut cost or stop the feature during a request flood. Also available via the `hamelp_ai_overview_mode` filter.
 
 ### 2.2.3
 

--- a/app/Hametuha/Hamelp/Hooks/AiOverview.php
+++ b/app/Hametuha/Hamelp/Hooks/AiOverview.php
@@ -74,6 +74,15 @@ class AiOverview extends Singleton {
 	 * @return true|\WP_Error
 	 */
 	public function check_permission( \WP_REST_Request $request ) {
+		// 0. Feature disabled (e.g. to stop a request flood).
+		if ( 'off' === hamelp_ai_overview_mode() ) {
+			return new \WP_Error(
+				'ai_overview_disabled',
+				__( 'AI Overview is currently disabled.', 'hamelp' ),
+				[ 'status' => 403 ]
+			);
+		}
+
 		// 1. Login required check.
 		$require_login = (bool) apply_filters( 'hamelp_ai_overview_require_login', get_option( 'hamelp_rate_require_login', '' ) );
 		if ( $require_login && ! is_user_logged_in() ) {
@@ -194,6 +203,11 @@ class AiOverview extends Singleton {
 	public function handle_request( \WP_REST_Request $request ) {
 		$query   = $request->get_param( 'query' );
 		$history = (array) $request->get_param( 'history' );
+
+		// In single-shot mode each question is independent: ignore prior turns.
+		if ( 'single' === hamelp_ai_overview_mode() ) {
+			$history = [];
+		}
 
 		// Check if AI is available
 		$prompt = wp_ai_client_prompt( $query );

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -172,6 +172,17 @@ class Settings extends Singleton {
 	 * Register settings and fields.
 	 */
 	public function register_settings() {
+		// AI Overview mode (feature switch).
+		register_setting(
+			self::OPTION_GROUP,
+			'hamelp_ai_overview_mode',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ $this, 'sanitize_mode' ],
+				'default'           => 'conversation',
+			]
+		);
+
 		// AI Overview fields.
 		$fields = $this->get_ai_fields();
 		foreach ( $fields as $suffix => $field ) {
@@ -192,6 +203,24 @@ class Settings extends Singleton {
 			__( 'AI Overview', 'hamelp' ),
 			[ $this, 'render_section' ],
 			self::PAGE_SLUG
+		);
+
+		add_settings_field(
+			'hamelp_ai_overview_mode',
+			__( 'Mode', 'hamelp' ),
+			[ $this, 'render_select' ],
+			self::PAGE_SLUG,
+			'hamelp_ai_section',
+			[
+				'option_name' => 'hamelp_ai_overview_mode',
+				'default'     => 'conversation',
+				'choices'     => [
+					'conversation' => __( 'Conversation (multi-turn): visitors can ask follow-up questions.', 'hamelp' ),
+					'single'       => __( 'Single answer: each question is answered independently (no follow-up, lower cost).', 'hamelp' ),
+					'off'          => __( 'Disabled: the AI Overview is turned off everywhere.', 'hamelp' ),
+				],
+				'description' => __( 'Controls how the AI Overview behaves. Switch to "Single answer" or "Disabled" to cut LLM cost or stop the feature during a request flood or abuse spike.', 'hamelp' ),
+			]
 		);
 
 		foreach ( $fields as $suffix => $field ) {
@@ -445,6 +474,40 @@ class Settings extends Singleton {
 			'<p class="description">%s</p>',
 			esc_html( $args['description'] )
 		);
+	}
+
+	/**
+	 * Render a select (dropdown) field.
+	 *
+	 * @param array $args Field arguments (option_name, choices, default, description).
+	 */
+	public function render_select( array $args ) {
+		$value   = get_option( $args['option_name'], $args['default'] ?? '' );
+		$choices = isset( $args['choices'] ) && is_array( $args['choices'] ) ? $args['choices'] : [];
+		printf( '<select name="%1$s" id="%1$s">', esc_attr( $args['option_name'] ) );
+		foreach ( $choices as $key => $label ) {
+			printf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( $key ),
+				selected( $value, $key, false ),
+				esc_html( $label )
+			);
+		}
+		echo '</select>';
+		if ( ! empty( $args['description'] ) ) {
+			printf( '<p class="description">%s</p>', esc_html( $args['description'] ) );
+		}
+	}
+
+	/**
+	 * Sanitize the AI Overview mode option.
+	 *
+	 * @param string $value Submitted value.
+	 * @return string A valid mode, defaulting to `conversation`.
+	 */
+	public function sanitize_mode( $value ) {
+		$allowed = [ 'conversation', 'single', 'off' ];
+		return in_array( $value, $allowed, true ) ? $value : 'conversation';
 	}
 
 	/**

--- a/hamelp.php
+++ b/hamelp.php
@@ -125,6 +125,26 @@ function hamelp_version_error() {
 }
 
 /**
+ * Get the AI Overview operating mode.
+ *
+ * - `conversation`: multi-turn conversation (default).
+ * - `single`: single-shot Q&A; prior turns are ignored (cheaper per request).
+ * - `off`: feature disabled (front-end renders nothing, REST is rejected).
+ *
+ * @return string One of `conversation`, `single`, `off`.
+ */
+function hamelp_ai_overview_mode() {
+	$mode = get_option( 'hamelp_ai_overview_mode', 'conversation' );
+	/**
+	 * Filter the AI Overview operating mode.
+	 *
+	 * @param string $mode One of `conversation`, `single`, `off`.
+	 */
+	$mode = apply_filters( 'hamelp_ai_overview_mode', $mode );
+	return in_array( $mode, [ 'conversation', 'single', 'off' ], true ) ? $mode : 'conversation';
+}
+
+/**
  * Get asset url
  *
  * @return string
@@ -266,6 +286,11 @@ function hamelp_render_search_box( $args = [] ) {
  * @return string HTML output.
  */
 function hamelp_render_ai_overview( $args = [] ) {
+	// When the feature is disabled (e.g. to stop a request flood), render nothing.
+	if ( 'off' === hamelp_ai_overview_mode() ) {
+		return '';
+	}
+
 	$args = wp_parse_args(
 		$args,
 		[

--- a/tests/test-ai-overview.php
+++ b/tests/test-ai-overview.php
@@ -129,4 +129,31 @@ class AiOverviewTest extends WP_UnitTestCase {
 	public function test_empty_history() {
 		$this->assertSame( [], $this->service->prepare_history( [] ) );
 	}
+
+	/**
+	 * The AI Overview mode defaults to conversation and honors option/filter.
+	 */
+	public function test_ai_overview_mode() {
+		$this->assertSame( 'conversation', hamelp_ai_overview_mode() );
+
+		update_option( 'hamelp_ai_overview_mode', 'single' );
+		$this->assertSame( 'single', hamelp_ai_overview_mode() );
+
+		update_option( 'hamelp_ai_overview_mode', 'off' );
+		$this->assertSame( 'off', hamelp_ai_overview_mode() );
+
+		// Invalid stored value falls back to the default.
+		update_option( 'hamelp_ai_overview_mode', 'bogus' );
+		$this->assertSame( 'conversation', hamelp_ai_overview_mode() );
+
+		// Filter override.
+		$filter = static function () {
+			return 'off';
+		};
+		add_filter( 'hamelp_ai_overview_mode', $filter );
+		$this->assertSame( 'off', hamelp_ai_overview_mode() );
+		remove_filter( 'hamelp_ai_overview_mode', $filter );
+
+		delete_option( 'hamelp_ai_overview_mode' );
+	}
 }


### PR DESCRIPTION
## 概要

AI Overview に**モード設定（プルダウン）**を追加しました。マスターのON/OFFだけでなく、コスト削減やリクエストフラッド・濫用時に中央で挙動を絞れるようにするのが狙いです。

設定画面の **AI Overview › Mode** で選択:

- **Conversation（多ターン・既定）**: 続けて質問できる従来の挙動。
- **Single answer**: 履歴を無視して単発QA。プロンプトが小さくなりコスト削減。
- **Disabled**: 機能を全面停止。前面に何も描画せず、REST も 403。

## 変更点

- `hamelp_ai_overview_mode()`（`hamelp.php`）＋同名フィルタ。`off`/`single`/`conversation` を返す（不正値は既定へ）。
- `hamelp_render_ai_overview()`: `off` のとき空文字を返す（ブロックは何も出力しない）。
- `AiOverview::check_permission()`: `off` のとき 403。`handle_request()`: `single` のとき履歴を無視。
- `Settings`: `hamelp_ai_overview_mode` 設定 ＋ `render_select` / `sanitize_mode`。AI Overview セクション先頭にプルダウンと説明文（フラッド対策である旨）。
- モードヘルパーの単体テスト。

## 検証

- `composer lint` / `composer phpstan` No errors、`npm test` 19/19（新規1：モードヘルパー）。
- **Playwright / wp-cli E2E**:
  - 設定画面にプルダウン（3択・既定 Conversation）が表示。
  - **off**: 前面にブロックが描画されない＋REST 直叩きで **403**。
  - **single**: 2ターン質問しても文脈が引き継がれない（「その場合」が返品と結び付かず独立回答）。
  - **conversation**: 文脈継続（既存PRで確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)