### PR TITLE
single モードでは各質問を独立した会話レコードとして保存する

### DIFF
--- a/app/Hametuha/Hamelp/Hooks/AiOverview.php
+++ b/app/Hametuha/Hamelp/Hooks/AiOverview.php
@@ -203,9 +203,10 @@ class AiOverview extends Singleton {
 	public function handle_request( \WP_REST_Request $request ) {
 		$query   = $request->get_param( 'query' );
 		$history = (array) $request->get_param( 'history' );
+		$single  = ( 'single' === hamelp_ai_overview_mode() );
 
 		// In single-shot mode each question is independent: ignore prior turns.
-		if ( 'single' === hamelp_ai_overview_mode() ) {
+		if ( $single ) {
 			$history = [];
 		}
 
@@ -233,14 +234,16 @@ class AiOverview extends Singleton {
 		// Done only after a successful answer so empty attempts are never stored.
 		$store = new ConversationStore();
 		if ( $store->is_enabled() ) {
-			$conversation_id = (string) $request->get_param( 'conversation_id' );
+			// In single-shot mode each question is an independent record, so the
+			// conversation id is not chained: every answer starts a new record.
+			$conversation_id = $single ? '' : (string) $request->get_param( 'conversation_id' );
 			$saved           = $store->save_turn(
 				'' !== $conversation_id ? $conversation_id : null,
 				$query,
 				(string) $result['answer'],
 				$result['cited_ids'] ?? []
 			);
-			if ( ! empty( $saved['uuid'] ) ) {
+			if ( ! $single && ! empty( $saved['uuid'] ) ) {
 				$result['conversation_id'] = $saved['uuid'];
 			}
 		}


### PR DESCRIPTION
## 概要

single モード時の保存挙動の修正。single モードは各質問が独立しているのに、`conversation_id` が往復して**1つの会話レコードにまとめられて**いた（最初の質問のタイトル配下に無関係な質問がぶら下がり、質問マイニングで紛らわしい）。

single モードのときは `conversation_id` を往復させず、**各質問を1レコード（1やりとり）として保存**するよう修正。

## 変更

- `AiOverview::handle_request()`: single モードでは保存時に `conversation_id` を無視し（常に新規レコード）、レスポンスにも `conversation_id` を返さない。
- conversation モードの挙動は不変。

## 検証

- `composer lint` / `composer phpstan` No errors。
- **Playwright/wp-cli E2E**: single モード＋保存ON で2問質問 → `hamelp_chat` が **2件の独立レコード**として作成され（各 turns=2＝1やりとり）、1件に合体しないことを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)