### PR TITLE
AI Overview フロントのモード対応（single置換／conversation引き継ぎトグル）

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 - Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.
 - Add an **Auto-delete After (days)** retention setting. A daily cron removes anonymous conversations older than the configured number of days (0 = never delete). Conversations from logged-in users are never auto-deleted.
 - Add an AI Overview **Mode** setting: *Conversation* (multi-turn, default), *Single answer* (no follow-up, lower cost), or *Disabled*. Use Single/Disabled to cut cost or stop the feature during a request flood. Also available via the `hamelp_ai_overview_mode` filter.
+- The front-end now reflects the mode: *Single answer* replaces the previous answer on each question, and *Conversation* shows a "Continue the previous conversation" toggle so visitors can either keep asking follow-ups or start a fresh conversation (which clears the thread).
 
 ### 2.2.3
 

--- a/hamelp.php
+++ b/hamelp.php
@@ -312,23 +312,40 @@ function hamelp_render_ai_overview( $args = [] ) {
 		}
 	}
 
+	$mode = hamelp_ai_overview_mode();
+
 	// Build wrapper attributes if not provided (non-block context).
 	if ( empty( $args['wrapper_attrs'] ) ) {
 		$args['wrapper_attrs'] = sprintf(
-			'class="hamelp-ai-overview" data-show-sources="%s"',
-			$args['show_sources'] ? 'true' : 'false'
+			'class="hamelp-ai-overview" data-show-sources="%s" data-mode="%s"',
+			$args['show_sources'] ? 'true' : 'false',
+			esc_attr( $mode )
+		);
+	}
+
+	// In conversation mode, offer a "carry over the previous conversation" toggle.
+	// Single mode answers each question independently, so no toggle is shown.
+	$continue_toggle = '';
+	if ( 'conversation' === $mode ) {
+		$continue_toggle = sprintf(
+			'<label class="hamelp-ai-overview__continue"><input type="checkbox" class="hamelp-ai-overview__continue-toggle" checked /> %s</label>',
+			esc_html__( 'Continue the previous conversation', 'hamelp' )
 		);
 	}
 
 	return sprintf(
-		'<div %s>
+		'<div %1$s>
 	<div class="hamelp-ai-overview__thread" aria-live="polite"></div>
 	<form class="hamelp-ai-overview__form">
-		<input type="text" class="hamelp-ai-overview__input" placeholder="%s" required />
-		<button type="submit" class="hamelp-ai-overview__button">%s</button>
+		%2$s
+		<div class="hamelp-ai-overview__input-row">
+			<input type="text" class="hamelp-ai-overview__input" placeholder="%3$s" required />
+			<button type="submit" class="hamelp-ai-overview__button">%4$s</button>
+		</div>
 	</form>
 </div>',
 		$args['wrapper_attrs'],
+		$continue_toggle, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- built from esc_html__ above.
 		esc_attr( $args['placeholder'] ),
 		esc_html( $args['button_text'] )
 	);

--- a/src/blocks/ai-overview/render.php
+++ b/src/blocks/ai-overview/render.php
@@ -14,6 +14,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 	[
 		'class'             => 'hamelp-ai-overview',
 		'data-show-sources' => $show_sources,
+		'data-mode'         => hamelp_ai_overview_mode(),
 	]
 );
 

--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -36,7 +36,21 @@
 
 :where(.hamelp-ai-overview__form) {
 	display: flex;
+	flex-direction: column;
 	gap: 0.5rem;
+}
+
+:where(.hamelp-ai-overview__input-row) {
+	display: flex;
+	gap: 0.5rem;
+}
+
+// "Continue the previous conversation" toggle (conversation mode only).
+:where(.hamelp-ai-overview__continue) {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.9em;
 }
 
 :where(.hamelp-ai-overview__input) {

--- a/src/blocks/ai-overview/view.js
+++ b/src/blocks/ai-overview/view.js
@@ -1,10 +1,15 @@
 /**
  * AI Overview Block Frontend Script
  *
- * Stateless multi-turn conversation: the prior turns are kept in memory on the
- * client and sent with every request as `history`. Nothing is persisted here
- * (history saving is a separate feature). The thread stacks question/answer
- * pairs; the form below stays available for follow-up questions.
+ * Behavior depends on the mode set on the container (`data-mode`):
+ * - `conversation`: prior turns are kept in memory and sent as `history` so the
+ *   answer has context. A "Continue the previous conversation" checkbox lets the
+ *   visitor either keep asking follow-ups or start fresh (which clears the
+ *   thread and starts a new conversation record).
+ * - `single`: each question is independent. The thread is cleared on every
+ *   submit so only the latest question and answer are shown (no context).
+ *
+ * Nothing is persisted client-side here (history saving is a separate feature).
  *
  * @package
  */
@@ -36,7 +41,9 @@ function renderSources( sources ) {
 
 document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 	const form = container.querySelector( 'form' );
-	const input = container.querySelector( 'input' );
+	// Select the text input specifically: the form may also contain the
+	// "continue" checkbox, so a bare `input` selector would match the wrong one.
+	const input = container.querySelector( '.hamelp-ai-overview__input' );
 	const thread = container.querySelector( '.hamelp-ai-overview__thread' );
 
 	if ( ! form || ! input || ! thread ) {
@@ -45,6 +52,10 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 
 	const button = container.querySelector( 'button' );
 	const showSources = container.dataset.showSources === 'true';
+	const mode = container.dataset.mode || 'conversation';
+	const continueToggle = container.querySelector(
+		'.hamelp-ai-overview__continue-toggle'
+	);
 
 	// In-memory conversation history: [{ role: 'user'|'assistant', content }].
 	const history = [];
@@ -57,6 +68,21 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 		const query = input.value.trim();
 		if ( ! query ) {
 			return;
+		}
+
+		// Decide whether this submit continues the current conversation or starts
+		// a new one. Single mode is always independent; conversation mode follows
+		// the toggle (and the first question always starts fresh).
+		const isContinue =
+			mode === 'conversation' &&
+			!! continueToggle?.checked &&
+			history.length > 0;
+
+		if ( ! isContinue ) {
+			// Start fresh: clear the visible thread and reset the conversation.
+			thread.innerHTML = '';
+			history.length = 0;
+			conversationId = '';
 		}
 
 		// Snapshot history to send (prior turns only, not the new question).


### PR DESCRIPTION
## 概要

これまでフロント（`view.js`）はモードを知らず、single モードでも回答が積み上がっていました。ブロックに `data-mode` を渡し、モードごとに挙動を変えます。

- **single**: 送信のたびにスレッドをクリアし、最新のQ&Aだけ表示（前の回答を消す＝置き換え）。
- **conversation**: 「前の会話を引き継ぐ」トグル（既定ON）を表示。
  - ON: 続けて質問（文脈継続・スレッドに積み上げ）。
  - OFF: 新しい質問（スレッドをクリアして新しい会話レコードを開始）。
- **off**: 従来どおり何も描画しない。

## 変更点

- `render.php` / `hamelp_render_ai_overview()`: ラッパーに `data-mode`。conversation 時のみ「引き継ぐ」チェックボックスを出力。フォームを縦並び化し入力行を `__input-row` に分離。
- `view.js`: `data-mode` とトグル状態を見て continue/new を判定。new のときスレッド・履歴・conversation_id をリセット。
- `style.scss`: フォーム縦並び＋入力行＋トグルのスタイル。
- **バグ修正**: チェックボックス追加で `querySelector('input')` がチェックボックスを誤検出し query に `"on"` が入っていた問題を、`.hamelp-ai-overview__input` 指定で解消（Playwrightで検出・修正）。

## 検証

- `composer lint` / `composer phpstan` No errors、`npm run lint:js`/`lint:css`、`npm test` 19/19。
- **Playwright E2E（wp-env）**:
  - **conversation + トグルON**: 2問が積み上がり「その場合」が返品文脈を理解（文脈継続）。
  - **conversation + トグルOFF**: 新しい質問でスレッドがクリアされ最新Q&Aのみ。
  - **single**: トグル非表示、送信ごとに置き換え（最新Q&Aのみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)