### PR TITLE
引き継ぎトグルを履歴ゼロのとき非表示にする

### DIFF
--- a/hamelp.php
+++ b/hamelp.php
@@ -327,8 +327,9 @@ function hamelp_render_ai_overview( $args = [] ) {
 	// Single mode answers each question independently, so no toggle is shown.
 	$continue_toggle = '';
 	if ( 'conversation' === $mode ) {
+		// Hidden until there is at least one exchange; view.js reveals it.
 		$continue_toggle = sprintf(
-			'<label class="hamelp-ai-overview__continue"><input type="checkbox" class="hamelp-ai-overview__continue-toggle" checked /> %s</label>',
+			'<label class="hamelp-ai-overview__continue" hidden><input type="checkbox" class="hamelp-ai-overview__continue-toggle" checked /> %s</label>',
 			esc_html__( 'Continue the previous conversation', 'hamelp' )
 		);
 	}

--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -46,7 +46,9 @@
 }
 
 // "Continue the previous conversation" toggle (conversation mode only).
-:where(.hamelp-ai-overview__continue) {
+// Scoped to :not([hidden]) so the `hidden` attribute (set until there is at
+// least one exchange) is honored instead of overridden by display:flex.
+:where(.hamelp-ai-overview__continue:not([hidden])) {
 	display: flex;
 	align-items: center;
 	gap: 0.4rem;

--- a/src/blocks/ai-overview/view.js
+++ b/src/blocks/ai-overview/view.js
@@ -53,6 +53,9 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 	const button = container.querySelector( 'button' );
 	const showSources = container.dataset.showSources === 'true';
 	const mode = container.dataset.mode || 'conversation';
+	const continueLabel = container.querySelector(
+		'.hamelp-ai-overview__continue'
+	);
 	const continueToggle = container.querySelector(
 		'.hamelp-ai-overview__continue-toggle'
 	);
@@ -62,6 +65,14 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 	// Server-issued conversation id (only when saving is enabled). Sent back on
 	// follow-up turns so the whole conversation is appended to one record.
 	let conversationId = '';
+
+	// The "continue" toggle is only meaningful once there is something to
+	// continue, so it stays hidden until the first exchange exists.
+	const updateContinueVisibility = () => {
+		if ( continueLabel ) {
+			continueLabel.hidden = history.length === 0;
+		}
+	};
 
 	form.addEventListener( 'submit', async ( e ) => {
 		e.preventDefault();
@@ -83,6 +94,7 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 			thread.innerHTML = '';
 			history.length = 0;
 			conversationId = '';
+			updateContinueVisibility();
 		}
 
 		// Snapshot history to send (prior turns only, not the new question).
@@ -139,6 +151,7 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 			// Record the completed exchange for the next turn's context.
 			history.push( { role: 'user', content: query } );
 			history.push( { role: 'assistant', content: data.answer } );
+			updateContinueVisibility();
 		} catch ( err ) {
 			answerEl.innerHTML = `<div class="hamelp-ai-overview__error">${
 				err.message || __( 'An error occurred.', 'hamelp' )


### PR DESCRIPTION
## 概要

conversation モードの「前の会話を引き継ぐ」トグルを、**履歴が1件もないときは非表示**にする。続けるものが無い初期状態でトグルを出すのは不自然なので、最初の回答が出てから表示する（スマートな既定）。

## 変更

- `hamelp_render_ai_overview()`: トグルの `<label>` を `hidden` 付きで出力。
- `view.js`: `updateContinueVisibility()` を追加し、履歴が1件以上になったら表示・新規開始でクリアされたら非表示。
- `style.scss`: `.hamelp-ai-overview__continue` の flex 指定を `:not([hidden])` にスコープし、`hidden` 属性が `display:flex` で打ち消されないように。

## 検証

- `composer lint` / `npm run lint:js` / `lint:css` / `npm run package` OK。
- **Playwright**: conversation モードで初期表示はトグル非表示（入力＋ボタンのみ）→ 最初の回答後にトグル（チェック済み）が出現することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)