### PR TITLE
デモ環境への自動デプロイ (demo.yml)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,6 +127,7 @@ npm test
 | `test.yml` | PR / push to master | PHP/JS/CSS lint, PHPUnit |
 | `release-drafter.yml` | push to master | リリースドラフト更新 |
 | `wordpress.yml` | release published | WordPress.orgへデプロイ |
+| `demo.yml` | push to master | デモ環境（さくらレンタルサーバー）へ rsync デプロイ。バージョンはコミットハッシュ |
 | `wp-outdated.yml` | 月次 (5日) | WPバージョンチェック、Issue作成 |
 
 ### リリースフロー
@@ -138,6 +139,15 @@ npm test
 
 - `WP_ORG_USERNAME`: WordPress.org SVNユーザー名
 - `WP_ORG_PASSWORD`: WordPress.org SVNパスワード
+- `KUNOICHI_DEMO_SAKURA_SSH`: デモ環境（さくら）デプロイ用SSH秘密鍵
+
+### デモ環境
+
+- master へ push されるたびに `demo.yml` がビルドして rsync デプロイ
+- 接続先: `kunoichi-demo@kunoichi-demo.sakura.ne.jp:/home/kunoichi-demo/www/demo.kunoichiwp.com/pubplafaq/wp-content/plugins/hamelp`
+- URL: https://demo.kunoichiwp.com/pubplafaq/ （environment: staging）
+- バージョン表記はコミットハッシュ（最新版の「予告」として機能）
+- 初回デプロイ後、プラグインの有効化は手動で1回必要
 
 ## ディレクトリ構造
 

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,56 @@
+name: Deploy to Demo
+
+on:
+  push:
+    branches:
+      - master
+
+# Only one demo deploy at a time; newer pushes supersede in-flight ones.
+concurrency:
+  group: deploy-demo
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy to demo
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://demo.kunoichiwp.com/pubplafaq/
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP with composer v2
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 7.4
+          tools: composer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Same build as the WordPress.org release, but the version becomes the
+      # short commit hash so the demo clearly shows a bleeding-edge build.
+      - name: Build package (version = commit hash)
+        run: bash bin/build.sh "${GITHUB_SHA:0:7}"
+
+      - name: Setup SSH key
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.KUNOICHI_DEMO_SAKURA_SSH }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H kunoichi-demo.sakura.ne.jp >> ~/.ssh/known_hosts 2>/dev/null
+
+      # Mirror the built plugin to the demo server. .distignore matches the
+      # WordPress.org distribution; --delete keeps the remote folder in sync.
+      - name: Deploy via rsync
+        run: |
+          rsync -rltvz --delete --chmod=D755,F644 \
+            --exclude-from=.distignore \
+            --exclude='tmp' \
+            -e "ssh -i ~/.ssh/deploy_key" \
+            ./ kunoichi-demo@kunoichi-demo.sakura.ne.jp:/home/kunoichi-demo/www/demo.kunoichiwp.com/pubplafaq/wp-content/plugins/hamelp/


### PR DESCRIPTION
## 概要

master へマージされるたびに、さくらレンタルサーバーのデモ環境へプラグインを自動デプロイします。最新版の「予告」としてユーザーに見てもらう用途。

## 内容

- **トリガー**: push to master（マージのたび）。`concurrency` で多重実行を抑制。
- **ビルド**: 既存の `bin/build.sh` を流用。ただし引数に**短縮コミットSHA**を渡し、`hamelp.php` の Version をコミットハッシュにする（タグではない）。
- **デプロイ**: `rsync -rltvz --delete --chmod=D755,F644 --exclude-from=.distignore`。WordPress.org 配布相当の中身を同期。
- **接続**: `kunoichi-demo@kunoichi-demo.sakura.ne.jp` 、鍵は `secrets.KUNOICHI_DEMO_SAKURA_SSH`、`ssh-keyscan` で known_hosts 登録。
- **対象**: `/home/kunoichi-demo/www/demo.kunoichiwp.com/pubplafaq/wp-content/plugins/hamelp`
- **environment**: `staging` / https://demo.kunoichiwp.com/pubplafaq/

## ローカル検証済み

- SSH 接続成功（`kunoichi-demo@www3952.sakura.ne.jp`）、対象パスの WordPress 構成を確認。
- `rsync --dry-run` で接続・パス・除外を検証：`vendor`/`assets`/`app`/`hamelp.php`/`wp-dependencies.json` が含まれ、`node_modules`/`.github`/`bin`/`tests`/`composer.json`/`package.json` は除外。

## マージ後

- この PR のマージ自体が初回デプロイを発火します。
- 初回のみ、デモ環境でプラグインの**有効化を手動で1回**お願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)