### PR TITLE
プラグイン名を Pubpla AI Help Center に変更 (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hamelp
+# Pubpla AI Help Center
 
 Contributors: tarosky, hametuha, Takahashi_Fumiki    
 Tags: faq,help  
@@ -30,7 +30,7 @@ It uses the [wp-ai-client](https://github.com/WordPress/wp-ai-client) bundled wi
 
 **Requirements:** AI Overview requires **WordPress 7.0 or later**. On older WordPress versions, the AI Overview block and template function will still appear in the editor and on the front-end, but the search form will not work (the REST endpoint that powers it is disabled). Other features of this plugin (FAQ custom post type, incremental search, shortcode) continue to work on WordPress 6.6+. Upgrade WordPress to 7.0 to enable AI Overview.
 
-You can configure AI behavior and rate limiting from **Settings > Hamelp** in the admin panel. The settings page also includes a **Rebuild Catalog Now** button to manually refresh the FAQ catalog used as LLM context.
+You can configure AI behavior and rate limiting from **Settings > Help Center** in the admin panel. The settings page also includes a **Rebuild Catalog Now** button to manually refresh the FAQ catalog used as LLM context.
 
 #### Using the Block
 
@@ -110,6 +110,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 ### 2.3.0
 
 - Change ownership to Tarosky.
+- Rename the plugin to **Pubpla AI Help Center**. The plugin slug, text domain, REST routes, and PHP APIs stay `hamelp` for backward compatibility, so no configuration or code changes are required.
 - AI Overview now supports **multi-turn conversations**. Follow-up questions keep the previous exchanges as context, and answers stack as a Q&A thread. Conversation history is held in the browser and sent with each request, so nothing is stored on the server.
 - Add `hamelp_history_window` filter to limit how many prior messages are sent to the LLM (default 10).
 - Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.

--- a/app/Hametuha/Hamelp/Commands.php
+++ b/app/Hametuha/Hamelp/Commands.php
@@ -10,7 +10,7 @@ namespace Hametuha\Hamelp;
 use Hametuha\Hamelp\Services\FaqCatalogBuilder;
 
 /**
- * Manage Hamelp FAQ system.
+ * Manage Pubpla AI Help Center FAQ system.
  */
 class Commands extends \WP_CLI_Command {
 

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -89,8 +89,8 @@ class Settings extends Singleton {
 	 */
 	public function add_menu_page() {
 		add_options_page(
-			__( 'Hamelp Settings', 'hamelp' ),
-			__( 'Hamelp', 'hamelp' ),
+			__( 'Pubpla AI Help Center', 'hamelp' ),
+			__( 'Help Center', 'hamelp' ),
 			'manage_options',
 			self::PAGE_SLUG,
 			[ $this, 'render_page' ]
@@ -345,7 +345,7 @@ class Settings extends Singleton {
 		$updated = $builder->get_last_updated();
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Hamelp Settings', 'hamelp' ); ?></h1>
+			<h1><?php esc_html_e( 'Pubpla AI Help Center', 'hamelp' ); ?></h1>
 
 			<?php if ( isset( $_GET['rebuilt'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
 				<div class="notice notice-success is-dismissible">

--- a/hamelp.php
+++ b/hamelp.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:     Hamelp
+ * Plugin Name:     Pubpla AI Help Center
  * Plugin URI:      https://wordpress.org/plugins/hamelp
  * Description:     AI powered FAQ and Help Document Management Plugin for WordPress.
  * Version:         2.3.0
@@ -121,7 +121,7 @@ add_action( 'init', 'hamelp_register_assets' );
  */
 function hamelp_version_error() {
 	// translators: %1$s required PHP version, %2$s current PHP version.
-	printf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'Hamelp requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamelp' ), '7.4', esc_html( phpversion() ) ) );
+	printf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'Pubpla AI Help Center requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamelp' ), '7.4', esc_html( phpversion() ) ) );
 }
 
 /**


### PR DESCRIPTION
## 概要

タロスカイ譲渡に伴い、プラグインの**表示名**を「Hamelp」→「**Pubpla AI Help Center**」に変更。Close #64

方針（#64 準拠）: **slug・テキストドメイン・名前空間・各種接頭辞は `hamelp` のまま**。表示名のみの変更なので、既存サイトの設定・保存データ・REST 連携・翻訳キーに影響なし。

## 変更（表示名）

| 箇所 | 値 |
|---|---|
| `hamelp.php` Plugin Name | Pubpla AI Help Center |
| README タイトル（=readme.txt表示名） | Pubpla AI Help Center |
| 設定ページ タイトル / H1 | Pubpla AI Help Center |
| PHP バージョン警告 | Pubpla AI Help Center |
| WP-CLI コマンド説明 | Pubpla AI Help Center |
| 設定**メニューのラベル**（狭い箱所） | **Help Center**（短縮形） |
| README「Settings > …」参照 | Help Center |

## 据え置き（識別子）

メインファイル `hamelp.php`（=slug）/ テキストドメイン `hamelp` / 名前空間 `Hametuha\Hamelp`・クラス `Hamelp` / `HamelpIncSearch`(JS) / 関数接頭辞 `hamelp_`・オプション・投稿タイプ `hamelp_chat`・REST `hamelp/v1`・CSS `hamelp-*` / WP-CLI `wp hamelp`

## 検証

- `composer lint` / `composer phpstan` No errors、`npm test` 19/19。
- wp-cli で確認: slug=`hamelp`（不変）、表示名（title）=「Pubpla AI Help Center」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)