### PR TITLE
fix: correct capitalization of PubPla (Pubpla → PubPla)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pubpla AI Help Center
+# PubPla AI Help Center
 
 Contributors: tarosky, hametuha, Takahashi_Fumiki    
 Tags: faq,help  
@@ -110,7 +110,7 @@ You can contribute to our github repo. Any [issues](https://github.com/tarosky/h
 ### 2.3.0
 
 - Change ownership to Tarosky.
-- Rename the plugin to **Pubpla AI Help Center**. The plugin slug, text domain, REST routes, and PHP APIs stay `hamelp` for backward compatibility, so no configuration or code changes are required.
+- Rename the plugin to **PubPla AI Help Center**. The plugin slug, text domain, REST routes, and PHP APIs stay `hamelp` for backward compatibility, so no configuration or code changes are required.
 - AI Overview now supports **multi-turn conversations**. Follow-up questions keep the previous exchanges as context, and answers stack as a Q&A thread. Conversation history is held in the browser and sent with each request, so nothing is stored on the server.
 - Add `hamelp_history_window` filter to limit how many prior messages are sent to the LLM (default 10).
 - Optionally **save conversations** for question mining (off by default). When enabled on the settings page, conversations are stored as a private post type viewable in the admin, so you can see what visitors actually ask. Toggle via the **Save Conversations** setting or the `hamelp_save_conversations` filter.

--- a/app/Hametuha/Hamelp/Commands.php
+++ b/app/Hametuha/Hamelp/Commands.php
@@ -10,7 +10,7 @@ namespace Hametuha\Hamelp;
 use Hametuha\Hamelp\Services\FaqCatalogBuilder;
 
 /**
- * Manage Pubpla AI Help Center FAQ system.
+ * Manage PubPla AI Help Center FAQ system.
  */
 class Commands extends \WP_CLI_Command {
 

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -89,7 +89,7 @@ class Settings extends Singleton {
 	 */
 	public function add_menu_page() {
 		add_options_page(
-			__( 'Pubpla AI Help Center', 'hamelp' ),
+			__( 'PubPla AI Help Center', 'hamelp' ),
 			__( 'Help Center', 'hamelp' ),
 			'manage_options',
 			self::PAGE_SLUG,
@@ -345,7 +345,7 @@ class Settings extends Singleton {
 		$updated = $builder->get_last_updated();
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Pubpla AI Help Center', 'hamelp' ); ?></h1>
+			<h1><?php esc_html_e( 'PubPla AI Help Center', 'hamelp' ); ?></h1>
 
 			<?php if ( isset( $_GET['rebuilt'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
 				<div class="notice notice-success is-dismissible">

--- a/hamelp.php
+++ b/hamelp.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name:     Pubpla AI Help Center
+ * Plugin Name:     PubPla AI Help Center
  * Plugin URI:      https://wordpress.org/plugins/hamelp
  * Description:     AI powered FAQ and Help Document Management Plugin for WordPress.
  * Version:         2.3.0
@@ -121,7 +121,7 @@ add_action( 'init', 'hamelp_register_assets' );
  */
 function hamelp_version_error() {
 	// translators: %1$s required PHP version, %2$s current PHP version.
-	printf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'Pubpla AI Help Center requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamelp' ), '7.4', esc_html( phpversion() ) ) );
+	printf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'PubPla AI Help Center requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamelp' ), '7.4', esc_html( phpversion() ) ) );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fix incorrect capitalization of the product name `Pubpla` → `PubPla` across 4 files (7 occurrences)
- All changes are UI-facing strings, doc comments, or documentation — no function names, slugs, or code identifiers were changed

## Files changed

- `README.md` — title and changelog entry
- `hamelp.php` — Plugin Name header and PHP version error message
- `app/Hametuha/Hamelp/Commands.php` — WP-CLI class docblock
- `app/Hametuha/Hamelp/Hooks/Settings.php` — admin page title and H1

🤖 Generated with [Claude Code](https://claude.com/claude-code)