### PR TITLE
Dependabot: 更新を1本にグループ化してPR乱立を防ぐ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,16 @@ updates:
     cooldown:
       default-days: 7
     allow:
-      - dependency-type: "direct"   # 推移的依存の単体PRを止める
+      - dependency-type: "direct"   # 推移的依存の単体PRを止める（脆弱性は下の security グループで拾う）
     groups:
-      dev-dependencies:
-        dependency-type: "development"
-        update-types: [ "minor", "patch" ]
+      # 通常のバージョン更新は major も含めて1本にまとめる（個別PRの乱立を防ぐ）
+      npm-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "major", "minor", "patch" ]
+      # 脆弱性修正（推移的依存含む）もまとめて1本に
+      npm-security:
+        applies-to: security-updates
+        patterns: [ "*" ]
 
   # 本番依存（composer / vendorに同梱される側）
   - package-ecosystem: "composer"
@@ -28,3 +33,10 @@ updates:
       default-days: 7
     allow:
       - dependency-type: "direct"
+    groups:
+      composer-dependencies:
+        patterns: [ "*" ]
+        update-types: [ "major", "minor", "patch" ]
+      composer-security:
+        applies-to: security-updates
+        patterns: [ "*" ]


### PR DESCRIPTION
## 背景

Dependabot 初回有効化で個別PRが大量に発生（npm系は全部 `package-lock.json` を書き換えるため、1本マージするたびに残りがリベースされる“もぐらたたき”）。

## 変更

`.github/dependabot.yml` のグループ化を強化:

- **バージョン更新**: npm / composer とも `patterns: ["*"]` ＋ `update-types: [major, minor, patch]` で**1グループに集約**。major も含めるので lint-staged / @wordpress/scripts / env などが個別PR化しなくなる。
- **脆弱性修正**: `applies-to: security-updates` のグループを追加し、推移的依存（qs, express, postcss 等）の security PR も**1本にまとめる**。
- weekly / cooldown 7日 / open-pull-requests-limit 5 / allow direct は維持。

これで通常は npm・composer 各「バージョン1本＋セキュリティ1本」程度に収まります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)