### PR TITLE
Add bin/demo.sh: drive the demo site via REST API

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,6 +149,32 @@ npm test
 - バージョン表記はコミットハッシュ（最新版の「予告」として機能）
 - 初回デプロイ後、プラグインの有効化は手動で1回必要
 
+#### デモサイトを REST API で操作する（`bin/demo.sh`）
+
+デモサイトの投稿作成・確認は **SSH ではなく REST API + Application Password** で行う。
+SSH をむやみに使わず、1ユーザーの権限の範囲だけを HTTPS Basic 認証で叩く（トークン単位で失効可能）。
+
+**初回セットアップ**
+
+1. デモサイトで専用 Editor ユーザー（例: `help-manager`）を作成
+2. そのユーザーで Application Password を発行（`ユーザー → プロフィール → アプリケーションパスワード`）
+3. `cp .envrc.example .envrc` して認証情報を記入（`.envrc` は gitignore 済み）
+4. `direnv allow`
+
+**使い方**
+
+```bash
+bin/demo.sh whoami                                          # 認証確認
+bin/demo.sh faq:list [--per_page 20]                        # FAQ一覧
+bin/demo.sh faq:create --title "Q" --content "A" [--status draft] [--category 12]
+bin/demo.sh get  /wp/v2/faq_category                        # 生GET（カテゴリID調査など）
+bin/demo.sh post /wp/v2/faq '{"title":"Q"}'                 # 生POST
+```
+
+- 認証情報は環境変数 `DEMO_URL` / `DEMO_USER` / `DEMO_APP_PASSWORD`（direnv が `.envrc` から export）。
+- Claude の実行シェルでは direnv フックが効かないことがあるため `direnv exec . bin/demo.sh ...` で叩く。
+- `.envrc` / `.envrc.example` は `.distignore` 済み（配布物・デモ rsync に含めない）。
+
 ## ディレクトリ構造
 
 ```

--- a/.distignore
+++ b/.distignore
@@ -4,6 +4,9 @@
 .editorconfig
 .git
 .gitignore
+.envrc
+.envrc.example
+.direnv
 .gitlab-ci.yml
 .husky
 .travis.yml

--- a/.envrc.example
+++ b/.envrc.example
@@ -1,0 +1,9 @@
+# direnv config for bin/demo.sh — copy to .envrc (git-ignored), then run `direnv allow`.
+#
+# Generate DEMO_APP_PASSWORD on the demo site:
+#   wp-admin > Users > Profile > Application Passwords
+# Use a dedicated Editor user (least privilege), not an administrator.
+
+export DEMO_URL="https://demo.kunoichiwp.com/pubplafaq/"
+export DEMO_USER="demo-bot"
+export DEMO_APP_PASSWORD="xxxx xxxx xxxx xxxx xxxx xxxx"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ tmp/
 .claude/settings.local.json
 /tasks/
 /tmp/
+
+# Local direnv config / demo REST credentials (do not commit)
+.envrc
+.direnv/

--- a/bin/demo.sh
+++ b/bin/demo.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Drive the demo site (https://demo.kunoichiwp.com/pubplafaq/) via the WordPress
+# REST API using an Application Password. No SSH, no shell access — just HTTPS
+# Basic Auth scoped to one user's capabilities, revocable per token.
+#
+# Credentials come from the environment (DEMO_URL, DEMO_USER, DEMO_APP_PASSWORD),
+# loaded by direnv from .envrc (git-ignored). See .envrc.example.
+#
+# Usage:
+#   bin/demo.sh whoami                         # verify credentials
+#   bin/demo.sh faq:list [--per_page 20]       # list FAQ posts
+#   bin/demo.sh faq:create --title "Q" --content "A" [--status draft] [--category 12]
+#   bin/demo.sh get  /wp/v2/faq                 # raw GET  against the REST API
+#   bin/demo.sh post /wp/v2/faq '{"title":"Q"}' # raw POST (JSON body)
+#
+set -euo pipefail
+
+hint='Run `direnv allow` after copying .envrc.example to .envrc.'
+: "${DEMO_URL:?DEMO_URL is not set. ${hint}}"
+: "${DEMO_USER:?DEMO_USER is not set. ${hint}}"
+: "${DEMO_APP_PASSWORD:?DEMO_APP_PASSWORD is not set. ${hint}}"
+
+API="${DEMO_URL%/}/wp-json"
+AUTH="${DEMO_USER}:${DEMO_APP_PASSWORD}"
+
+# Pretty-print JSON if jq is available, otherwise pass through.
+pp() { if command -v jq >/dev/null 2>&1; then jq .; else cat; fi; }
+
+api() {
+	local method="$1" path="$2" body="${3:-}"
+	local url="${API}${path}"
+	if [[ -n "${body}" ]]; then
+		curl -fsS -u "${AUTH}" -X "${method}" -H "Content-Type: application/json" -d "${body}" "${url}"
+	else
+		curl -fsS -u "${AUTH}" -X "${method}" "${url}"
+	fi
+}
+
+# Minimal JSON string escaper (handles quotes, backslashes, newlines).
+json_escape() {
+	local s="$1"
+	s="${s//\\/\\\\}"
+	s="${s//\"/\\\"}"
+	s="${s//$'\n'/\\n}"
+	printf '%s' "${s}"
+}
+
+cmd="${1:-}"; shift || true
+
+case "${cmd}" in
+	whoami)
+		api GET /wp/v2/users/me | pp
+		;;
+
+	faq:list)
+		query="per_page=10"
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+				--per_page) query="per_page=$2"; shift 2 ;;
+				*) echo "Unknown option: $1" >&2; exit 1 ;;
+			esac
+		done
+		api GET "/wp/v2/faq?${query}&_fields=id,title,status,link" | pp
+		;;
+
+	faq:create)
+		title="" content="" status="publish" category=""
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+				--title)    title="$2";    shift 2 ;;
+				--content)  content="$2";  shift 2 ;;
+				--status)   status="$2";   shift 2 ;;
+				--category) category="$2"; shift 2 ;;
+				*) echo "Unknown option: $1" >&2; exit 1 ;;
+			esac
+		done
+		[[ -n "${title}" ]] || { echo "Error: --title is required" >&2; exit 1; }
+		body="{\"title\":\"$(json_escape "${title}")\",\"content\":\"$(json_escape "${content}")\",\"status\":\"$(json_escape "${status}")\""
+		if [[ -n "${category}" ]]; then
+			body="${body},\"faq_category\":[${category}]"
+		fi
+		body="${body}}"
+		api POST /wp/v2/faq "${body}" | pp
+		;;
+
+	get)
+		[[ $# -ge 1 ]] || { echo "Usage: bin/demo.sh get <path>" >&2; exit 1; }
+		api GET "$1" | pp
+		;;
+
+	post)
+		[[ $# -ge 2 ]] || { echo "Usage: bin/demo.sh post <path> <json>" >&2; exit 1; }
+		api POST "$1" "$2" | pp
+		;;
+
+	*)
+		grep -E '^#( |$)' "${BASH_SOURCE[0]}" | sed -E 's/^# ?//'
+		exit 1
+		;;
+esac


### PR DESCRIPTION
## 概要

デモサイト（https://demo.kunoichiwp.com/pubplafaq/）の投稿作成・確認を、**SSH ではなく WordPress REST API + Application Password** で行うための curl ラッパ `bin/demo.sh` を追加します。

SSH をむやみに使わず、1ユーザーの権限の範囲だけを HTTPS Basic 認証で操作できます（トークン単位で失効可能・blast radius が狭い）。

## 変更点

- **`bin/demo.sh`**: `whoami` / `faq:list` / `faq:create` / 生の `get`・`post` サブコマンド
- **`.envrc.example`**: direnv テンプレ。認証情報の実体 `.envrc` は `.gitignore`
- **`.distignore`**: `.envrc` / `.envrc.example` / `.direnv` を追加（配布物・デモ rsync から除外。`bin` は既存で除外済み）
- **`.claude/CLAUDE.md`**: セットアップと使い方を追記

## セットアップ

1. デモサイトで専用 Editor ユーザーを作成 → Application Password を発行
2. `cp .envrc.example .envrc` で認証情報を記入 → `direnv allow`

## 動作確認

- `bin/demo.sh whoami` → デモサイトの Editor ユーザーで認証成功（書き込み権限あり）を確認済み
- `bin/demo.sh faq:list` → REST エンドポイント正常応答を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)