### PR TITLE
Fix: WP.org short description over 150 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 AI powered FAQ and Help Document Management Plugin for WordPress. 
 
-**Live demo:** https://demo.kunoichiwp.com/pubplafaq/ — Try the AI Overview on the front page. The demo is in Japanese, built around a fictional anti-aging subscription "Jovian", but you can still get a feel for how the AI answers real questions from your FAQ content (and admits when something isn't covered).
-
 ## Description
+
+**Live demo:** https://demo.kunoichiwp.com/pubplafaq/ — Try the AI Overview on the front page. The demo is in Japanese, built around a fictional anti-aging subscription "Jovian", but you can still get a feel for how the AI answers real questions from your FAQ content (and admits when something isn't covered).
 
 This plugin add new custom post type 'FAQ'. With some functionality, you can build help center for your user.
 What is help center? We collect examples at our [github wiki](https://github.com/tarosky/hamelp/wiki).


### PR DESCRIPTION
Closes #88

## 概要

WordPress.org のインポート時に「Short Description が150字超で切り詰められた」警告が出ていた件の修正。

## 原因

`readme.txt` は `bin/build.sh` 内の `wp-readme.php` が README.md から生成する。WP.org の Short Description は「ヘッダーブロック〜最初のセクション見出し」の本文に対応する。#87 で追加した **Live demo 段落**がこのゾーンに入り込み、本来66字の短い説明が150字超になっていた。

## 修正

- Live demo 段落を `## Description` セクション内へ移動。
- Short Description ゾーンは冒頭タグライン1行のみ（**66字** ≤ 150）に。

## 検証

- README の短い説明ゾーンがタグライン1行だけになり、文字数 66 を確認。
- Live demo リンクは Description 内に保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)