### PR TITLE
improve: change AI Overview conversation toggle text to "Continue this conversation"

### DIFF
--- a/hamelp.php
+++ b/hamelp.php
@@ -330,7 +330,7 @@ function hamelp_render_ai_overview( $args = [] ) {
 		// Hidden until there is at least one exchange; view.js reveals it.
 		$continue_toggle = sprintf(
 			'<label class="hamelp-ai-overview__continue" hidden><input type="checkbox" class="hamelp-ai-overview__continue-toggle" checked /> %s</label>',
-			esc_html__( 'Continue the previous conversation', 'hamelp' )
+			esc_html__( 'Continue this conversation', 'hamelp' )
 		);
 	}
 


### PR DESCRIPTION
## Summary

- Change the AI Overview conversation toggle label from **"Continue the previous conversation"** to **"Continue this conversation"**

## Reason

The new text is more intuitive since users can see the conversation thread directly above the checkbox, making "this conversation" a more natural and clear reference than "the previous conversation".

## Files changed

- `hamelp.php:333`

🤖 Generated with [Claude Code](https://claude.com/claude-code)