### PR TITLE
AIオーバービューの引用ラベルを設定可能・翻訳可能にする

### DIFF
--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -223,6 +223,30 @@ class Settings extends Singleton {
 			]
 		);
 
+		// Citation reference label (customizable, translatable).
+		register_setting(
+			self::OPTION_GROUP,
+			'hamelp_ref_label',
+			[
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'default'           => __( '(Ref. %d)', 'hamelp' ),
+			]
+		);
+
+		add_settings_field(
+			'hamelp_ref_label',
+			__( 'Citation Label', 'hamelp' ),
+			[ $this, 'render_text' ],
+			self::PAGE_SLUG,
+			'hamelp_ai_section',
+			[
+				'option_name' => 'hamelp_ref_label',
+				'default'     => __( '(Ref. %d)', 'hamelp' ),
+				'description' => __( 'Label shown for each inline citation in AI answers. Use %d as a placeholder for the citation number.', 'hamelp' ),
+			]
+		);
+
 		foreach ( $fields as $suffix => $field ) {
 			$option_name = self::OPTION_PREFIX . $suffix;
 			add_settings_field(
@@ -474,6 +498,27 @@ class Settings extends Singleton {
 			'<p class="description">%s</p>',
 			esc_html( $args['description'] )
 		);
+	}
+
+	/**
+	 * Render a text input field.
+	 *
+	 * @param array $args Field arguments.
+	 */
+	public function render_text( array $args ) {
+		$value = get_option( $args['option_name'], $args['default'] ?? '' );
+		printf(
+			'<input type="text" name="%s" id="%s" value="%s" class="regular-text" />',
+			esc_attr( $args['option_name'] ),
+			esc_attr( $args['option_name'] ),
+			esc_attr( $value )
+		);
+		if ( ! empty( $args['description'] ) ) {
+			printf(
+				'<p class="description">%s</p>',
+				esc_html( $args['description'] )
+			);
+		}
 	}
 
 	/**

--- a/hamelp.php
+++ b/hamelp.php
@@ -145,6 +145,23 @@ function hamelp_ai_overview_mode() {
 }
 
 /**
+ * Get the citation reference label template.
+ *
+ * `%d` is replaced with the citation's index (1-based) at render time.
+ *
+ * @return string Label template, e.g. `(Ref. %d)`.
+ */
+function hamelp_ref_label() {
+	$label = get_option( 'hamelp_ref_label', __( '(Ref. %d)', 'hamelp' ) );
+	/**
+	 * Filter the citation reference label template.
+	 *
+	 * @param string $label Label template containing `%d`.
+	 */
+	return apply_filters( 'hamelp_ref_label', $label );
+}
+
+/**
  * Get asset url
  *
  * @return string
@@ -317,9 +334,10 @@ function hamelp_render_ai_overview( $args = [] ) {
 	// Build wrapper attributes if not provided (non-block context).
 	if ( empty( $args['wrapper_attrs'] ) ) {
 		$args['wrapper_attrs'] = sprintf(
-			'class="hamelp-ai-overview" data-show-sources="%s" data-mode="%s"',
+			'class="hamelp-ai-overview" data-show-sources="%s" data-mode="%s" data-ref-label="%s"',
 			$args['show_sources'] ? 'true' : 'false',
-			esc_attr( $mode )
+			esc_attr( $mode ),
+			esc_attr( hamelp_ref_label() )
 		);
 	}
 

--- a/src/blocks/ai-overview/render.php
+++ b/src/blocks/ai-overview/render.php
@@ -15,6 +15,7 @@ $wrapper_attributes = get_block_wrapper_attributes(
 		'class'             => 'hamelp-ai-overview',
 		'data-show-sources' => $show_sources,
 		'data-mode'         => hamelp_ai_overview_mode(),
+		'data-ref-label'    => hamelp_ref_label(),
 	]
 );
 

--- a/src/blocks/ai-overview/utils.js
+++ b/src/blocks/ai-overview/utils.js
@@ -101,14 +101,18 @@ export function parseMarkdown( text ) {
  *
  * Handles both single [ID:42] and comma-separated [ID:42, ID:55] patterns.
  *
- * @param {string} html    Parsed HTML string.
- * @param {Array}  sources Array of { id, title, url } objects.
+ * @param {string} html     Parsed HTML string.
+ * @param {Array}  sources  Array of { id, title, url } objects.
+ * @param {string} refLabel Label template for each citation; `%d` is
+ *                          replaced with the citation's index. Defaults to
+ *                          `(Ref. %d)` when empty.
  * @return {string} HTML with references replaced by links.
  */
-export function replaceIdReferences( html, sources ) {
+export function replaceIdReferences( html, sources, refLabel ) {
 	if ( ! sources?.length ) {
 		return html;
 	}
+	const label = refLabel || '(Ref. %d)';
 	const sourceMap = {};
 	sources.forEach( ( source, i ) => {
 		sourceMap[ source.id ] = { ...source, index: i + 1 };
@@ -120,9 +124,11 @@ export function replaceIdReferences( html, sources ) {
 		const refs = ids
 			.map( ( id ) => {
 				const source = sourceMap[ id ];
-				return source
-					? `<a href="${ source.url }" class="hamelp-ai-overview__ref" title="${ source.title }">(Ref. ${ source.index })</a>`
-					: null;
+				if ( ! source ) {
+					return null;
+				}
+				const text = label.replace( /%d/g, source.index );
+				return `<a href="${ source.url }" class="hamelp-ai-overview__ref" title="${ source.title }">${ text }</a>`;
 			} )
 			.filter( Boolean );
 		return refs.length ? refs.join( ' ' ) : match;

--- a/src/blocks/ai-overview/view.js
+++ b/src/blocks/ai-overview/view.js
@@ -53,6 +53,7 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 	const button = container.querySelector( 'button' );
 	const showSources = container.dataset.showSources === 'true';
 	const mode = container.dataset.mode || 'conversation';
+	const refLabel = container.dataset.refLabel;
 	const continueLabel = container.querySelector(
 		'.hamelp-ai-overview__continue'
 	);
@@ -138,7 +139,8 @@ document.querySelectorAll( '.hamelp-ai-overview' ).forEach( ( container ) => {
 			// Parse markdown, then replace [ID:xxx] with source links.
 			const parsedAnswer = replaceIdReferences(
 				parseMarkdown( data.answer ),
-				data.sources
+				data.sources,
+				refLabel
 			);
 			let html = parsedAnswer;
 			if ( showSources ) {

--- a/tests/js/ai-overview-utils.test.js
+++ b/tests/js/ai-overview-utils.test.js
@@ -145,4 +145,28 @@ describe( 'replaceIdReferences', () => {
 		const result = replaceIdReferences( 'See [ID:100].', sources );
 		expect( result ).toContain( 'title="FAQ One"' );
 	} );
+
+	it( 'uses a custom refLabel template when provided', () => {
+		const result = replaceIdReferences(
+			'See [ID:100].',
+			sources,
+			'出典:%d'
+		);
+		expect( result ).toContain( '出典:1' );
+		expect( result ).not.toContain( '(Ref. 1)' );
+	} );
+
+	it( 'substitutes every %d occurrence in a custom refLabel', () => {
+		const result = replaceIdReferences(
+			'See [ID:200].',
+			sources,
+			'[%d] (source #%d)'
+		);
+		expect( result ).toContain( '[2] (source #2)' );
+	} );
+
+	it( 'falls back to the default label when refLabel is empty', () => {
+		const result = replaceIdReferences( 'See [ID:100].', sources, '' );
+		expect( result ).toContain( '(Ref. 1)' );
+	} );
 } );


### PR DESCRIPTION
## Summary
- Settings > Help Center に「Citation Label」フィールドを追加（デフォルト `(Ref. %d)`、`%d` は引用番号に置換）
- `hamelp_ref_label()` ヘルパーを追加し、`data-ref-label` 属性としてブロック/ウィジェット双方のフロントに渡す
- `utils.js` の `replaceIdReferences()` がハードコードされた `(Ref. N)` ではなく、`%d` プレースホルダー方式のラベルを使うように変更（未設定時は従来と同じ `(Ref. %d)` にフォールバックするため既存サイトの表示は変わらない）

Fixes #93

## Test plan
- [x] `npm run test:js` — 既存テスト + カスタムラベル/複数`%d`/空ラベルフォールバックの新規テスト、全て pass
- [x] `composer lint` — pass
- [x] `npm run build:blocks` でビルドし、コンパイル後の `render.php` / `view.js` に変更が反映されていることを確認
- [ ] デモサイトでの動作確認（依頼者側で実施予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)