### PR TITLE
READMEを更新し、バージョンを2.3.1に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: tarosky, hametuha, Takahashi_Fumiki    
 Tags: faq,help  
 Tested up to: 7.0  
-Stable Tag: 2.2.3  
+Stable Tag: 2.3.1  
 License: GPL 3.0 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -11,10 +11,12 @@ AI powered FAQ and Help Document Management Plugin for WordPress.
 
 ## Description
 
-**Live demo:** https://demo.kunoichiwp.com/pubplafaq/ — Try the AI Overview on the front page. The demo is in Japanese, built around a fictional anti-aging subscription "Jovian", but you can still get a feel for how the AI answers real questions from your FAQ content (and admits when something isn't covered).
-
 This plugin add new custom post type 'FAQ'. With some functionality, you can build help center for your user.
 What is help center? We collect examples at our [github wiki](https://github.com/tarosky/hamelp/wiki).
+
+**Live demo:** https://demo.kunoichiwp.com/pubplafaq/ — Try the AI Overview on the front page. The demo is in Japanese, built around a fictional anti-aging subscription "Jovian", but you can still get a feel for how the AI answers real questions from your FAQ content (and admits when something isn't covered).
+
+[![WordPress Plugin Test](https://github.com/tarosky/hamelp/actions/workflows/test.yml/badge.svg)](https://github.com/tarosky/hamelp/actions/workflows/test.yml)
 
 ### Creating Portal
 
@@ -108,6 +110,10 @@ Install itself is easy. Auto install from admin panel is recommended. Search wit
 You can contribute to our github repo. Any [issues](https://github.com/tarosky/hamelp/issues) or [PRs](https://github.com/tarosky/hamelp/pulls) are welcomed.
 
 ## Changelog
+
+### 2.3.1
+
+- User can change the reference prefix (Ref. 1).
 
 ### 2.3.0
 

--- a/hamelp.php
+++ b/hamelp.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PubPla AI Help Center
  * Plugin URI:      https://wordpress.org/plugins/hamelp
  * Description:     AI powered FAQ and Help Document Management Plugin for WordPress.
- * Version:         2.3.0
+ * Version:         2.3.1
  * Author:          Tarosky
  * Author URI:      https://tarosky.co.jp
  * Domain Path:     /languages


### PR DESCRIPTION
## Summary
- Description内のLive demoリンクの位置を整理し、CI（test.yml）バッジを追加
- Changelogに2.3.1（引用ラベルのカスタマイズ機能）を追記
- プラグイン本体のバージョンを2.3.0 → 2.3.1に更新

Note: #96（AIオーバービューの引用ラベルを設定可能にする機能）を先にマージしてから、こちらをマージ・リリースしてください（changelogの内容と対応するため）。

## Test plan
- [x] `composer lint` — pass
- [ ] マージ後、リリースドラフトを確認しwp.orgへ公開

🤖 Generated with [Claude Code](https://claude.com/claude-code)