### PR TITLE
AI Overview: モデル選択UIとtemperature設定を追加（複数コネクタ対応・temperature 400修正）

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,9 @@
 	"phpVersion": "7.4",
 	"plugins": [
 		".",
-		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip"
+		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/ai-provider-for-google.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/ai-provider-for-anthropic.latest-stable.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.latest-stable.zip"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contributors: tarosky, hametuha, Takahashi_Fumiki    
 Tags: faq,help  
 Tested up to: 7.0  
-Stable Tag: 2.3.1  
+Stable Tag: 2.4.0  
 License: GPL 3.0 or later  
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -110,6 +110,14 @@ Install itself is easy. Auto install from admin panel is recommended. Search wit
 You can contribute to our github repo. Any [issues](https://github.com/tarosky/hamelp/issues) or [PRs](https://github.com/tarosky/hamelp/pulls) are welcomed.
 
 ## Changelog
+
+For full release notes of each version, see [GitHub Releases](https://github.com/tarosky/hamelp/releases).
+
+### 2.4.0
+
+- Add an **AI Model** setting to pin the provider/model used for AI Overview. Only configured connectors (WordPress 7.0 Settings → Connectors) are listed, and if the chosen model later becomes unavailable it falls back to auto-selection instead of failing.
+- Change the default **temperature** to omitted. Some models (e.g. Claude Opus/Sonnet) reject a temperature and returned a 400 error when auto-selected; omitting is safe for every model. Set a value on the settings page only if you need it.
+- Add `hamelp_ai_model` and `hamelp_ai_temperature` filters to override the model and temperature from code.
 
 ### 2.3.1
 

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -8,6 +8,7 @@
 namespace Hametuha\Hamelp\Hooks;
 
 use Hametuha\Hamelp\Pattern\Singleton;
+use Hametuha\Hamelp\Services\AiModelResolver;
 use Hametuha\Hamelp\Services\FaqCatalogBuilder;
 
 /**
@@ -220,6 +221,52 @@ class Settings extends Singleton {
 					'off'          => __( 'Disabled: the AI Overview is turned off everywhere.', 'hamelp' ),
 				],
 				'description' => __( 'Controls how the AI Overview behaves. Switch to "Single answer" or "Disabled" to cut LLM cost or stop the feature during a request flood or abuse spike.', 'hamelp' ),
+			]
+		);
+
+		// Preferred AI model (auto-select by default; validated against the live registry).
+		register_setting(
+			self::OPTION_GROUP,
+			AiModelResolver::OPTION_MODEL,
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ $this, 'sanitize_model' ],
+				'default'           => '',
+			]
+		);
+
+		add_settings_field(
+			AiModelResolver::OPTION_MODEL,
+			__( 'AI Model', 'hamelp' ),
+			[ $this, 'render_model_select' ],
+			self::PAGE_SLUG,
+			'hamelp_ai_section',
+			[
+				'option_name' => AiModelResolver::OPTION_MODEL,
+			]
+		);
+
+		// Sampling temperature (blank omits the parameter, e.g. for Claude Opus).
+		register_setting(
+			self::OPTION_GROUP,
+			AiModelResolver::OPTION_TEMPERATURE,
+			[
+				'type'              => 'string',
+				'sanitize_callback' => [ $this, 'sanitize_temperature' ],
+				'default'           => '0.3',
+			]
+		);
+
+		add_settings_field(
+			AiModelResolver::OPTION_TEMPERATURE,
+			__( 'Temperature', 'hamelp' ),
+			[ $this, 'render_text' ],
+			self::PAGE_SLUG,
+			'hamelp_ai_section',
+			[
+				'option_name' => AiModelResolver::OPTION_TEMPERATURE,
+				'default'     => '0.3',
+				'description' => __( 'Sampling temperature between 0 and 2 (e.g. 0.3). Leave blank to omit it entirely — required for models that reject a temperature, such as Claude Opus.', 'hamelp' ),
 			]
 		);
 
@@ -553,6 +600,91 @@ class Settings extends Singleton {
 	public function sanitize_mode( $value ) {
 		$allowed = [ 'conversation', 'single', 'off' ];
 		return in_array( $value, $allowed, true ) ? $value : 'conversation';
+	}
+
+	/**
+	 * Render the AI model select field.
+	 *
+	 * Choices are built from the live registry so only currently configured
+	 * providers/models appear. Warns when a previously saved model is no longer
+	 * available (e.g. its connector was disabled outside Hamelp).
+	 *
+	 * @param array $args Field arguments (option_name).
+	 */
+	public function render_model_select( array $args ) {
+		if ( ! AiModelResolver::is_ai_available() ) {
+			printf(
+				'<p class="description">%s</p>',
+				esc_html__( 'No AI provider is available. Connect one in Settings → Connectors, then reload this page.', 'hamelp' )
+			);
+			return;
+		}
+
+		$value   = (string) get_option( $args['option_name'], '' );
+		$choices = [ '' => __( 'Auto (recommended)', 'hamelp' ) ] + AiModelResolver::get_available_models();
+
+		printf( '<select name="%1$s" id="%1$s">', esc_attr( $args['option_name'] ) );
+		foreach ( $choices as $key => $label ) {
+			printf(
+				'<option value="%s" %s>%s</option>',
+				esc_attr( $key ),
+				selected( $value, $key, false ),
+				esc_html( $label )
+			);
+		}
+		echo '</select>';
+
+		if ( AiModelResolver::is_stored_model_stale() ) {
+			printf(
+				'<p class="description" style="color:#b32d2e;">%s</p>',
+				esc_html__( 'The previously selected model is no longer available (its connector may have been disabled). Auto-selection is being used until you choose an available model.', 'hamelp' )
+			);
+		}
+
+		printf(
+			'<p class="description">%s</p>',
+			esc_html__( 'Pin the provider/model used for AI Overview. Only configured connectors are listed. If the chosen model becomes unavailable, Hamelp falls back to auto-selection instead of failing.', 'hamelp' )
+		);
+	}
+
+	/**
+	 * Sanitize the AI model option.
+	 *
+	 * Accepts only the empty string (auto) or a currently available
+	 * `provider_id|model_id` value; anything else resets to auto.
+	 *
+	 * @param string $value Submitted value.
+	 * @return string A valid model key, or empty string for auto-select.
+	 */
+	public function sanitize_model( $value ) {
+		$value = (string) $value;
+		if ( '' === $value ) {
+			return '';
+		}
+		$available = AiModelResolver::get_available_models();
+		return isset( $available[ $value ] ) ? $value : '';
+	}
+
+	/**
+	 * Sanitize the temperature option.
+	 *
+	 * Empty string is preserved (omit the parameter). A numeric value is clamped
+	 * to the 0–2 range. Any other input falls back to the default.
+	 *
+	 * @param string $value Submitted value.
+	 * @return string Sanitized temperature, or empty string to omit it.
+	 */
+	public function sanitize_temperature( $value ) {
+		$value = trim( (string) $value );
+		if ( '' === $value ) {
+			return '';
+		}
+		if ( ! is_numeric( $value ) ) {
+			return '0.3';
+		}
+		$float = (float) $value;
+		$float = max( 0.0, min( 2.0, $float ) );
+		return (string) $float;
 	}
 
 	/**

--- a/app/Hametuha/Hamelp/Hooks/Settings.php
+++ b/app/Hametuha/Hamelp/Hooks/Settings.php
@@ -246,14 +246,14 @@ class Settings extends Singleton {
 			]
 		);
 
-		// Sampling temperature (blank omits the parameter, e.g. for Claude Opus).
+		// Sampling temperature (blank = omit, which is the default and safe for all models).
 		register_setting(
 			self::OPTION_GROUP,
 			AiModelResolver::OPTION_TEMPERATURE,
 			[
 				'type'              => 'string',
 				'sanitize_callback' => [ $this, 'sanitize_temperature' ],
-				'default'           => '0.3',
+				'default'           => '',
 			]
 		);
 
@@ -265,8 +265,8 @@ class Settings extends Singleton {
 			'hamelp_ai_section',
 			[
 				'option_name' => AiModelResolver::OPTION_TEMPERATURE,
-				'default'     => '0.3',
-				'description' => __( 'Sampling temperature between 0 and 2 (e.g. 0.3). Leave blank to omit it entirely — required for models that reject a temperature, such as Claude Opus.', 'hamelp' ),
+				'default'     => '',
+				'description' => __( 'Sampling temperature between 0 and 2 (e.g. 0.3). Leave blank (the default) to omit it entirely — omitting is safe for every model, whereas some models (e.g. Claude Opus) return an error if a temperature is supplied.', 'hamelp' ),
 			]
 		);
 

--- a/app/Hametuha/Hamelp/Services/AiModelResolver.php
+++ b/app/Hametuha/Hamelp/Services/AiModelResolver.php
@@ -35,8 +35,8 @@ class AiModelResolver {
 	/**
 	 * Option holding the sampling temperature.
 	 *
-	 * Empty string means "omit the parameter" (required by models such as
-	 * Claude Opus that reject a temperature). Defaults to `0.3`.
+	 * Empty string means "omit the parameter" and is the default, since omitting
+	 * is safe for every model while some (e.g. Claude Opus) reject a temperature.
 	 *
 	 * @var string
 	 */
@@ -130,7 +130,7 @@ class AiModelResolver {
 	 * @return float|null Temperature, or null to omit the parameter entirely.
 	 */
 	public static function get_effective_temperature(): ?float {
-		$stored = get_option( self::OPTION_TEMPERATURE, '0.3' );
+		$stored = get_option( self::OPTION_TEMPERATURE, '' );
 		if ( '' === $stored || null === $stored ) {
 			return null;
 		}

--- a/app/Hametuha/Hamelp/Services/AiModelResolver.php
+++ b/app/Hametuha/Hamelp/Services/AiModelResolver.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * AI model resolution and enumeration.
+ *
+ * @package hamelp
+ */
+
+namespace Hametuha\Hamelp\Services;
+
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Models\DTO\ModelRequirements;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+
+/**
+ * Bridges the WordPress 7.0 AI client registry with Hamelp settings.
+ *
+ * Everything here reads the *live* registry so that connectors toggled on or
+ * off outside Hamelp (Settings → Connectors) are always reflected. A stored
+ * model selection is never trusted blindly: it is validated against the
+ * currently configured providers on every request, and a selection that no
+ * longer exists silently falls back to auto-selection rather than pinning a
+ * dead model endpoint.
+ */
+class AiModelResolver {
+
+	/**
+	 * Option holding the preferred model, formatted `provider_id|model_id`.
+	 *
+	 * Empty string means "auto-select".
+	 *
+	 * @var string
+	 */
+	const OPTION_MODEL = 'hamelp_ai_model';
+
+	/**
+	 * Option holding the sampling temperature.
+	 *
+	 * Empty string means "omit the parameter" (required by models such as
+	 * Claude Opus that reject a temperature). Defaults to `0.3`.
+	 *
+	 * @var string
+	 */
+	const OPTION_TEMPERATURE = 'hamelp_ai_temperature';
+
+	/**
+	 * Separator between provider id and model id in the stored option value.
+	 *
+	 * @var string
+	 */
+	const SEPARATOR = '|';
+
+	/**
+	 * Whether the WordPress AI client is available in this environment.
+	 *
+	 * @return bool
+	 */
+	public static function is_ai_available(): bool {
+		return function_exists( 'wp_ai_client_prompt' )
+			&& function_exists( 'wp_supports_ai' )
+			&& wp_supports_ai()
+			&& class_exists( '\WordPress\AiClient\AiClient' );
+	}
+
+	/**
+	 * Enumerate configured providers/models capable of text generation.
+	 *
+	 * Only providers that are currently configured (connector enabled and
+	 * authenticated) are returned, so the list mirrors the live registry.
+	 *
+	 * @return array<string, string> Map of `provider_id|model_id` => `Provider / Model` label.
+	 */
+	public static function get_available_models(): array {
+		if ( ! self::is_ai_available() ) {
+			return [];
+		}
+
+		$models = [];
+		try {
+			$registry     = AiClient::defaultRegistry();
+			$requirements = new ModelRequirements( [ CapabilityEnum::textGeneration() ], [] );
+			foreach ( $registry->findModelsMetadataForSupport( $requirements ) as $provider_models ) {
+				$provider      = $provider_models->getProvider();
+				$provider_id   = $provider->getId();
+				$provider_name = $provider->getName();
+				foreach ( $provider_models->getModels() as $model ) {
+					$key            = $provider_id . self::SEPARATOR . $model->getId();
+					$models[ $key ] = sprintf( '%s / %s', $provider_name, $model->getName() );
+				}
+			}
+		} catch ( \Throwable $e ) {
+			// Registry not ready or provider misbehaving: degrade to auto-select.
+			return [];
+		}
+
+		return $models;
+	}
+
+	/**
+	 * Resolve the effective model preference for a generation request.
+	 *
+	 * Returns a `[ provider_id, model_id ]` pair suitable for the AI client's
+	 * model preference API, or null to let the client auto-select. A stored
+	 * selection that is no longer available resolves to null.
+	 *
+	 * @return array{0: string, 1: string}|null
+	 */
+	public static function get_effective_model_preference(): ?array {
+		$stored = (string) get_option( self::OPTION_MODEL, '' );
+		if ( '' === $stored ) {
+			return null;
+		}
+
+		// Validate against the live registry so a removed/disabled model is dropped.
+		$available = self::get_available_models();
+		if ( ! isset( $available[ $stored ] ) ) {
+			return null;
+		}
+
+		$parts = explode( self::SEPARATOR, $stored, 2 );
+		if ( 2 !== count( $parts ) || '' === $parts[0] || '' === $parts[1] ) {
+			return null;
+		}
+
+		return [ $parts[0], $parts[1] ];
+	}
+
+	/**
+	 * Resolve the effective temperature for a generation request.
+	 *
+	 * @return float|null Temperature, or null to omit the parameter entirely.
+	 */
+	public static function get_effective_temperature(): ?float {
+		$stored = get_option( self::OPTION_TEMPERATURE, '0.3' );
+		if ( '' === $stored || null === $stored ) {
+			return null;
+		}
+		return (float) $stored;
+	}
+
+	/**
+	 * Whether a stored model selection has become unavailable.
+	 *
+	 * Used by the settings screen to warn that a previously chosen model is no
+	 * longer offered (e.g. its connector was disabled outside Hamelp).
+	 *
+	 * @return bool
+	 */
+	public static function is_stored_model_stale(): bool {
+		$stored = (string) get_option( self::OPTION_MODEL, '' );
+		if ( '' === $stored ) {
+			return false;
+		}
+		$available = self::get_available_models();
+		return ! isset( $available[ $stored ] );
+	}
+}

--- a/app/Hametuha/Hamelp/Services/FaqSearchService.php
+++ b/app/Hametuha/Hamelp/Services/FaqSearchService.php
@@ -80,17 +80,17 @@ class FaqSearchService {
 		/**
 		 * Filter the preferred AI model for FAQ overview generation.
 		 *
-		 * By default the AI client auto-selects a configured provider/model.
-		 * Return a value to pin a specific model, which is useful when a site
-		 * has several providers connected. Accepted forms mirror the AI client's
-		 * model preference API:
+		 * The default is resolved from the Hamelp settings screen and validated
+		 * against the live provider registry, so a selection whose connector was
+		 * disabled outside Hamelp falls back to auto-selection. Return a value to
+		 * override. Accepted forms mirror the AI client's model preference API:
 		 *
 		 * - a model ID string, e.g. `'gemini-2.5-flash'`
 		 * - a `[ provider_id, model_id ]` pair, e.g. `[ 'anthropic', 'claude-opus-4-1' ]`
 		 *
-		 * @param string|array|null $model Preferred model. Null (default) auto-selects.
+		 * @param string|array|null $model Preferred model. Null auto-selects.
 		 */
-		$model = apply_filters( 'hamelp_ai_model', null );
+		$model = apply_filters( 'hamelp_ai_model', AiModelResolver::get_effective_model_preference() );
 		if ( ! empty( $model ) ) {
 			$prompt = $prompt->using_model_preference( $model );
 		}
@@ -98,13 +98,14 @@ class FaqSearchService {
 		/**
 		 * Filter the sampling temperature for FAQ overview generation.
 		 *
-		 * Return `null` to omit the temperature entirely. This is required for
-		 * models that reject the parameter (e.g. Claude Opus responds with a
-		 * 400 error when a temperature is supplied).
+		 * The default is resolved from the Hamelp settings screen. Return `null`
+		 * to omit the temperature entirely. This is required for models that
+		 * reject the parameter (e.g. Claude Opus responds with a 400 error when a
+		 * temperature is supplied).
 		 *
-		 * @param float|null $temperature Sampling temperature. Default 0.3. Null omits it.
+		 * @param float|null $temperature Sampling temperature. Null omits it.
 		 */
-		$temperature = apply_filters( 'hamelp_ai_temperature', 0.3 );
+		$temperature = apply_filters( 'hamelp_ai_temperature', AiModelResolver::get_effective_temperature() );
 		if ( null !== $temperature ) {
 			$prompt = $prompt->using_temperature( (float) $temperature );
 		}

--- a/app/Hametuha/Hamelp/Services/FaqSearchService.php
+++ b/app/Hametuha/Hamelp/Services/FaqSearchService.php
@@ -74,9 +74,42 @@ class FaqSearchService {
 		}
 		$messages[] = new UserMessage( [ new MessagePart( $query ) ] );
 
-		$response = wp_ai_client_prompt( $messages )
-			->using_system_instruction( $system_prompt )
-			->using_temperature( 0.3 )
+		$prompt = wp_ai_client_prompt( $messages )
+			->using_system_instruction( $system_prompt );
+
+		/**
+		 * Filter the preferred AI model for FAQ overview generation.
+		 *
+		 * By default the AI client auto-selects a configured provider/model.
+		 * Return a value to pin a specific model, which is useful when a site
+		 * has several providers connected. Accepted forms mirror the AI client's
+		 * model preference API:
+		 *
+		 * - a model ID string, e.g. `'gemini-2.5-flash'`
+		 * - a `[ provider_id, model_id ]` pair, e.g. `[ 'anthropic', 'claude-opus-4-1' ]`
+		 *
+		 * @param string|array|null $model Preferred model. Null (default) auto-selects.
+		 */
+		$model = apply_filters( 'hamelp_ai_model', null );
+		if ( ! empty( $model ) ) {
+			$prompt = $prompt->using_model_preference( $model );
+		}
+
+		/**
+		 * Filter the sampling temperature for FAQ overview generation.
+		 *
+		 * Return `null` to omit the temperature entirely. This is required for
+		 * models that reject the parameter (e.g. Claude Opus responds with a
+		 * 400 error when a temperature is supplied).
+		 *
+		 * @param float|null $temperature Sampling temperature. Default 0.3. Null omits it.
+		 */
+		$temperature = apply_filters( 'hamelp_ai_temperature', 0.3 );
+		if ( null !== $temperature ) {
+			$prompt = $prompt->using_temperature( (float) $temperature );
+		}
+
+		$response = $prompt
 			->as_json_response()
 			->generate_text();
 

--- a/hamelp.php
+++ b/hamelp.php
@@ -3,7 +3,7 @@
  * Plugin Name:     PubPla AI Help Center
  * Plugin URI:      https://wordpress.org/plugins/hamelp
  * Description:     AI powered FAQ and Help Document Management Plugin for WordPress.
- * Version:         2.3.1
+ * Version:         2.4.0
  * Author:          Tarosky
  * Author URI:      https://tarosky.co.jp
  * Domain Path:     /languages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "hamelp",
-	"version": "2.3.0",
+	"version": "2.4.0",
 	"description": "FAQ generator for WordPress",
 	"scripts": {
 		"test": "RESULT=${PWD##*/} && wp-env run tests-cli ./wp-content/plugins/$RESULT/vendor/bin/phpunit -c ./wp-content/plugins/$RESULT/phpunit.xml.dist",

--- a/phpstan/stubs/wp-ai-client.stub
+++ b/phpstan/stubs/wp-ai-client.stub
@@ -59,3 +59,58 @@ namespace WordPress\AiClient\Messages\DTO {
 		public function __construct( array $parts ) {}
 	}
 }
+
+namespace WordPress\AiClient {
+	class AiClient {
+		public static function defaultRegistry(): \WordPress\AiClient\Providers\ProviderRegistry {}
+	}
+}
+
+namespace WordPress\AiClient\Providers {
+	class ProviderRegistry {
+		/**
+		 * @param \WordPress\AiClient\Providers\Models\DTO\ModelRequirements $requirements
+		 * @return \WordPress\AiClient\Providers\DTO\ProviderModelsMetadata[]
+		 */
+		public function findModelsMetadataForSupport( $requirements ): array {}
+	}
+}
+
+namespace WordPress\AiClient\Providers\DTO {
+	class ProviderMetadata {
+		public function getId(): string {}
+
+		public function getName(): string {}
+	}
+
+	class ProviderModelsMetadata {
+		public function getProvider(): \WordPress\AiClient\Providers\DTO\ProviderMetadata {}
+
+		/**
+		 * @return \WordPress\AiClient\Providers\Models\DTO\ModelMetadata[]
+		 */
+		public function getModels(): array {}
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\DTO {
+	class ModelMetadata {
+		public function getId(): string {}
+
+		public function getName(): string {}
+	}
+
+	class ModelRequirements {
+		/**
+		 * @param \WordPress\AiClient\Providers\Models\Enums\CapabilityEnum[] $requiredCapabilities
+		 * @param array                                                      $requiredOptions
+		 */
+		public function __construct( array $requiredCapabilities, array $requiredOptions ) {}
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\Enums {
+	class CapabilityEnum {
+		public static function textGeneration(): self {}
+	}
+}

--- a/phpstan/stubs/wp-ai-client.stub
+++ b/phpstan/stubs/wp-ai-client.stub
@@ -17,6 +17,11 @@ namespace {
 	class WP_AI_Client_Prompt_Builder {
 		public function using_system_instruction( string $instruction ): self {}
 
+		/**
+		 * @param string|array|\WordPress\AiClient\Providers\Models\Contracts\ModelInterface ...$preferredModels
+		 */
+		public function using_model_preference( ...$preferredModels ): self {}
+
 		public function using_temperature( float $temperature ): self {}
 
 		public function as_json_response( ?array $schema = null ): self {}


### PR DESCRIPTION
## 概要

AI Overview で使用する **AIモデルと temperature を設定可能**にする。複数の AI コネクタ（プロバイダ）が有効なサイトで、意図したモデルを固定できるようにし、temperature 非対応モデルでのエラーを解消する。

## 背景・きっかけ

デモ環境で AI が全滅した件（社内Slack）を、WP 7.0 コア + php-ai-client を精読のうえ wp-env(WP7.0)＋Anthropic/Google の実キーで再現検証した。

- hamelp は `wp_ai_client_prompt()` を **モデル無指定** で呼ぶため、AIクライアントが自動選択する。
- 自動選択は「最初に登録されたプロバイダの最初のモデル」を採用。登録順はプラグインのロード順（≒フォルダ名のアルファベット順）で `ai-provider-for-anthropic` が `-google` より先 → **Anthropic（claude-sonnet-5）が選ばれる**。
- hamelp が `temperature 0.3` を無条件付与していたため、temperature 非対応の Claude 系で **`400 temperature is deprecated for this model`** となっていた。

実測:

| ケース | 結果 |
|---|---|
| Auto + temp 0.3 | ❌ 400 |
| Opus/Sonnet 固定 + temp 0.3 | ❌ 400 |
| Opus 固定 + temp 省略 | ✅ OK |
| Auto + temp 省略（本PRの新既定） | ✅ OK |

## 変更内容

- **temperature の既定を「省略（空欄）」に変更**。省略は全モデルで安全。`0.3` 等を使いたい場合のみ明示入力する。
- **設定画面に「AIモデル選択」を追加**。ライブのプロバイダレジストリから **設定済みコネクタのみ** を動的列挙する。
- **堅牢性**: 保存済みの選択は毎リクエストでレジストリと照合し、コネクタが hamelp 外（Settings → Connectors）で無効化されるなどして利用不可になった場合は **自動選択にフォールバック**（死んだモデルIDを渡さない）。失効時は設定画面に警告表示。
- フィルタ `hamelp_ai_model` / `hamelp_ai_temperature` を追加（設定値をコードから上書き可能）。
- レジストリ introspection は `Services/AiModelResolver` に分離。
- PHPStan スタブ（`phpstan/stubs/wp-ai-client.stub`）に使用するコアAPIを追加。
- dev: `.wp-env.json` に Google/Anthropic のプロバイダを追加し、ローカルで検証可能にした。

## 検証

- wp-env(WP 7.0) 実機で end-to-end 確認（上表）。管理画面のレンダリングは Playwright で確認。
- `composer lint`（PHPCS）/ PHPStan(level 5) いずれもパス。

## 注意（前回の見立てとの差分）

前回 Slack で挙がった「WP7.0コアのコネクタ→認証受け渡しバグ」は、コードを読む限り裏付けが取れなかった（素の構成では正常動作）。本PRで再現・修正したのは temperature 起因の 400 であり、`RequestAuthenticationInterface instance not set`（認証系）とは別エラー。認証側は再現できていないため、再発時は実環境での切り分けが必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
