### PR TITLE
AI Overview: 出典表示を Sources: + 番号付きリストに改善

### DIFF
--- a/src/blocks/ai-overview/style.scss
+++ b/src/blocks/ai-overview/style.scss
@@ -176,9 +176,11 @@
 	font-weight: var(--hamelp-font-weight, 600);
 }
 
-:where(.hamelp-ai-overview__sources ul) {
+:where(.hamelp-ai-overview__sources ol) {
 	margin: 0;
 	padding-left: 1.5rem;
+	// Numbered so the list index matches the inline "Ref. N" citations.
+	list-style: decimal;
 }
 
 :where(.hamelp-ai-overview__sources li) {

--- a/src/blocks/ai-overview/view.js
+++ b/src/blocks/ai-overview/view.js
@@ -30,12 +30,12 @@ function renderSources( sources ) {
 	}
 	let html =
 		'<div class="hamelp-ai-overview__sources"><p>' +
-		__( 'Related FAQs:', 'hamelp' ) +
-		'</p><ul>';
+		__( 'Sources:', 'hamelp' ) +
+		'</p><ol>';
 	sources.forEach( ( source ) => {
 		html += `<li><a href="${ source.url }">${ source.title }</a></li>`;
 	} );
-	html += '</ul></div>';
+	html += '</ol></div>';
 	return html;
 }
 


### PR DESCRIPTION
Fixes #98 (partially) / AI Overview の出典表示改善

## 背景

AI Overview の回答は本文中に `(Ref. 1)` `(Ref. 2)` … のインライン引用を出すが、下の一覧が「Related FAQs（関連するFAQ）」というラベルの **箇条書き（ul）** だったため、番号と一覧が視覚的に結びつかなかった。

## 変更

- 見出しを **`Related FAQs:` → `Sources:`** に変更（出典であることを明記）。
- 一覧を **`<ul>` → `<ol>`** にして番号を表示。本文中の `(Ref. N)` と一覧の番号が一致する。
  - 採番は元々 `sources` 配列順（`replaceIdReferences` の `index=i+1`）で、一覧も同じ配列・同じ順で描画しているため、**番号は元から1対1対応済み**。表示上の番号が出ていなかっただけ。

## 検証

wp-env(WP 7.0)＋実キーでフロントから質問し、Playwright で確認:

- インライン `(Ref.1)`→/faq/add-comment/、`(Ref.2)`→/faq/how-to-register/ … が、`Sources:` の 1.〜6. とURL単位で完全一致。
- `<ol>` の番号（1〜6）が本文の Ref 番号と揃うことをスクリーンショットで確認。
- `npm run lint`（JS/CSS）パス。

## 補足

- `Sources:` は JS 文字列だが、`block.json` の `textdomain` + ビルド生成 `view.asset.php` の `wp-i18n` 依存により、WPコアが自動で `wp_set_script_translations` を呼ぶ（`wp-includes/blocks.php`）。よって翻訳可能。日本語表示は translate.wordpress.org（GlotPress）で `Sources:`（例: 「出典:」）を訳せば反映される。→ #98 の翻訳作業とあわせて対応。
- バージョン/Changelog は本PRでは触っていない（2.4.0 は #99 が保持）。リリース方針に合わせて追記します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
