### PR TITLE
Fix: AI Overviewの二重JSONで回答が壊れる問題（スキーマ強制＋アンラップ）

### DIFF
--- a/app/Hametuha/Hamelp/Services/FaqSearchService.php
+++ b/app/Hametuha/Hamelp/Services/FaqSearchService.php
@@ -111,15 +111,15 @@ class FaqSearchService {
 		}
 
 		$response = $prompt
-			->as_json_response()
+			->as_json_response( self::response_schema() )
 			->generate_text();
 
 		if ( is_wp_error( $response ) ) {
 			return $response;
 		}
 
-		$data = json_decode( $response, true );
-		if ( ! $data || ! isset( $data['answer'] ) ) {
+		$data = self::decode_json_response( $response );
+		if ( null === $data ) {
 			// JSON parse failed: treat response as plain text.
 			return [
 				'answer'    => $response,
@@ -147,6 +147,69 @@ class FaqSearchService {
 			'sources'   => $sources,
 			'cited_ids' => wp_list_pluck( $sources, 'id' ),
 		];
+	}
+
+	/**
+	 * JSON schema constraining the model's structured output.
+	 *
+	 * Passed to `as_json_response()` so providers that support structured output
+	 * enforce the exact `{ answer, cited_ids }` shape. `additionalProperties` is
+	 * explicitly false because some providers (e.g. Anthropic) reject object
+	 * schemas without it.
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected static function response_schema(): array {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				'answer'    => [ 'type' => 'string' ],
+				'cited_ids' => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'integer' ],
+				],
+			],
+			'required'             => [ 'answer', 'cited_ids' ],
+		];
+	}
+
+	/**
+	 * Decode the model's JSON response, unwrapping double-encoded output.
+	 *
+	 * Even with a response schema, some models occasionally return the whole
+	 * `{ answer, cited_ids }` object as a JSON string nested inside the `answer`
+	 * field. This unwraps up to a few levels so the real answer and citations
+	 * are recovered instead of leaking raw JSON to the user with empty sources.
+	 *
+	 * @param string $response Raw text returned by the model.
+	 * @return array|null Decoded `{ answer, cited_ids }` array, or null if unusable.
+	 */
+	public static function decode_json_response( string $response ): ?array {
+		$data  = json_decode( $response, true );
+		$depth = 0;
+		while (
+			is_array( $data )
+			&& isset( $data['answer'] )
+			&& is_string( $data['answer'] )
+			&& $depth < 3
+		) {
+			$trimmed = trim( $data['answer'] );
+			if ( '' === $trimmed || '{' !== $trimmed[0] ) {
+				break;
+			}
+			$inner = json_decode( $trimmed, true );
+			if ( ! is_array( $inner ) || ! isset( $inner['answer'] ) ) {
+				break;
+			}
+			$data = $inner;
+			++$depth;
+		}
+
+		if ( ! is_array( $data ) || ! isset( $data['answer'] ) ) {
+			return null;
+		}
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
## 症状

ステージングで AI Overview の REST 応答がこうなっていた（回答が生JSONのまま・`sources` 空）:

```json
{ "answer": "{\n  \"answer\": \"WordPress…[ID:273]…[ID:281]。\",\n  \"cited_ids\": [273, 281]\n}\n", "sources": [] }
```

`answer` の中に本来の `{answer, cited_ids}` がまるごと**文字列として二重に**入り、`cited_ids` を外側から拾えず `sources` が空になっていた。

## 原因

`FaqSearchService` が JSON を**二重に指示**していた:
1. `->as_json_response()`（**スキーマ無し**）
2. システムプロンプトで「`{answer, cited_ids}` で返せ」

この二重指示により、モデルによっては要求どおりのJSONを *文字列化して* `answer` に入れて返す。モデル非依存の設計上の弱点で、**Gemini でも非決定的に発生**（ステージングで確認）。

## 修正

- `as_json_response()` に `{answer:string, cited_ids:int[]}` の **JSON スキーマを渡して構造化出力を強制**（根本対策）。`additionalProperties:false` は Anthropic が必須。
- `decode_json_response()` を追加し、二重エンコードを**最大3段アンラップ**する保険を実装。回答本文と `cited_ids` を復元し `sources` も正しく構築される。誤アンラップ防止（`{`始まりでも非対象JSONは保持）・プレーンテキストは従来どおり null フォールバック。

## 検証

- **決定的テスト**（純PHP）: ステージングの二重ペイロードを投入 → `answer`=「WordPressを採用…」/ `cited_ids`=[273,281] に復元。normal/plain-text/エッジも期待どおり。
- **スキーマのクロスプロバイダ確認**: Gemini 2.5 / 3.5、Anthropic Sonnet 5 いずれも `additionalProperties:false` 付きスキーマで正常応答。
- **end-to-end**（wp-env WP7.0 実キー）: `generate_overview` を Gemini / Anthropic で実行 → clean な回答・sources あり・二重化なし。
- PHPCS / PHPStan パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
