### PR TITLE
tarosky/workflows のClaude系GitHub Actionsを導入

### DIFF
--- a/.github/workflows/claude-assistant.yml
+++ b/.github/workflows/claude-assistant.yml
@@ -1,0 +1,13 @@
+name: Claude Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  assistant:
+    if: "!contains(github.event.comment.body, '@claude auto-review')"
+    uses: tarosky/workflows/.github/workflows/claude-assistant.yml@main
+    secrets: inherit

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,93 @@
+name: Claude Code PR Review
+
+on:
+  workflow_run:
+    workflows: ["WordPress Plugin Test"]
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  # CI 全パス後の自動レビュー（同一リポジトリのPRのみ）
+  setup:
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Get PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(gh pr list --head "${{ github.event.workflow_run.head_branch }}" --json number --jq '.[0].number')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+  auto-review:
+    needs: setup
+    if: needs.setup.outputs.pr_number != ''
+    uses: tarosky/workflows/.github/workflows/claude-review.yml@main
+    with:
+      plugin_name: hamelp
+      ci_checks: "PHPUnit (PHP 7.4/8.3 × WP latest/6.6), PHPCS, PHPStan, PHP lint, JS/CSS lint, JS unit test"
+      pr_number: ${{ fromJSON(needs.setup.outputs.pr_number) }}
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      custom_focus: |
+        - AI Overview / FAQ 生成でユーザー入力を LLM に渡す箇所のプロンプトインジェクション対策
+        - AI の入力・出力のサニタイズとエスケープ（特にHTML出力時）
+        - REST API エンドポイントの permission_callback / 権限チェック
+        - 設定画面・FAQ生成処理の nonce / capability チェック
+        - 翻訳文字列のテキストドメイン統一（i18n）
+    secrets: inherit
+
+  # "@claude auto-review" で手動レビュー（メンバーのみ、PRコメントのみ）
+  manual-setup:
+    if: |
+      github.event_name == 'issue_comment' &&
+      contains(github.event.comment.body, '@claude auto-review') &&
+      github.event.issue.pull_request &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.pr.outputs.number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+    steps:
+      - name: Get PR info
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.issue.number }}
+          HEAD_SHA=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json headRefOid --jq '.headRefOid')
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+
+  manual-review:
+    needs: manual-setup
+    if: needs.manual-setup.outputs.pr_number != ''
+    uses: tarosky/workflows/.github/workflows/claude-review.yml@main
+    with:
+      plugin_name: hamelp
+      ci_checks: "PHPUnit (PHP 7.4/8.3 × WP latest/6.6), PHPCS, PHPStan, PHP lint, JS/CSS lint, JS unit test"
+      pr_number: ${{ fromJSON(needs.manual-setup.outputs.pr_number) }}
+      head_sha: ${{ needs.manual-setup.outputs.head_sha }}
+      is_manual: true
+      custom_focus: |
+        - AI Overview / FAQ 生成でユーザー入力を LLM に渡す箇所のプロンプトインジェクション対策
+        - AI の入力・出力のサニタイズとエスケープ（特にHTML出力時）
+        - REST API エンドポイントの permission_callback / 権限チェック
+        - 設定画面・FAQ生成処理の nonce / capability チェック
+        - 翻訳文字列のテキストドメイン統一（i18n）
+    secrets: inherit

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,20 @@
+name: Issue Triage
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'  # 毎週月曜 01:00 UTC
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "何日以内に作成されたIssueを対象にするか（デフォルト: 30）"
+        required: false
+        type: string
+        default: '30'
+
+jobs:
+  triage:
+    uses: tarosky/workflows/.github/workflows/issue-triage.yml@main
+    with:
+      plugin_name: hamelp
+      days: ${{ fromJSON(inputs.days || '30') }}
+    secrets: inherit

--- a/.github/workflows/wp-plugin-audit.yml
+++ b/.github/workflows/wp-plugin-audit.yml
@@ -1,0 +1,14 @@
+name: WP Plugin Audit
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  audit:
+    uses: tarosky/workflows/.github/workflows/plugin-audit.yml@main
+    with:
+      slug: hamelp
+      language: ja
+    secrets: inherit


### PR DESCRIPTION
## 概要

hametuha → tarosky への移行に伴い、`tarosky/workflows` の共通 Claude reusable workflow を rich-taxonomy と同様に導入します。

## 追加したワークフロー

| ファイル | トリガー | 内容 |
|---|---|---|
| `claude-assistant.yml` | Issue/PRコメント作成 | `@claude` メンションに応答（メンバー限定） |
| `claude-review.yml` | `WordPress Plugin Test` 成功後 / `@claude auto-review` | CI全パス後の自動PRレビュー、および手動レビュー |
| `issue-triage.yml` | 週次（月曜 01:00 UTC）/ 手動 | Issueの自動トリアージ・ラベル付け |
| `wp-plugin-audit.yml` | 月次（1日 00:00 UTC）/ 手動 | WordPress.org公開プラグインの監査Issue作成 |

## hamelp固有の調整（rich-taxonomyとの差分）

- **test workflow名**: rich-taxonomy は `"Test Plugin"` だが hamelp は `"WordPress Plugin Test"` のため、`claude-review.yml` の `workflow_run.workflows` を合わせた（これが合っていないと自動レビューが発火しない）
- **ブランチ**: `main` → `master`
- **plugin_name / slug**: `hamelp`
- **custom_focus**: AI Overview / FAQ 生成でユーザー入力をLLMに渡す性質を踏まえ、プロンプトインジェクション対策・AI入出力のサニタイズ/エスケープ・REST API権限チェック・nonce/capability・i18n をレビュー観点に設定
- **ci_checks**: hamelp の CI 構成（PHPUnit 7.4/8.3 × WP latest/6.6, PHPCS, PHPStan, PHP lint, JS/CSS lint, JS unit test）を記載

## ⚠️ マージ前の確認事項

- これらは `secrets: inherit` で org-level の **`ANTHROPIC_API_KEY`** を利用します。org secret が selected repos スコープの場合、**hamelp リポジトリがスコープに含まれているか要確認**（org admin 権限が必要なため当方では未確認）。
- 各 reusable workflow が要求する `ANTHROPIC_API_KEY` が hamelp から見えていれば、追加設定は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)